### PR TITLE
feat: improve rail labels and contextual GUI help

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,7 @@ PRINTER_ROUTING_FILE=config/TBG3002/printer-routing.yaml
 # Rail label PDF calibration (inches)
 # Positive offsets move the whole grid right/down.
 ############################################
-RAIL_LABEL_CENTER_GAP_IN=0.125
+RAIL_LABEL_CENTER_GAP_IN=0.1875
 RAIL_LABEL_OFFSET_X_IN=0.02
 RAIL_LABEL_OFFSET_Y_IN=0.02
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,13 @@ jobs:
             if (-not $pomVersion) {
               throw "Could not resolve project version from pom.xml for PR build metadata."
             }
+            if ($pomVersion -notmatch '^(?<core>\d+\.\d+\.\d+)(?<suffix>-[0-9A-Za-z.-]+)?$') {
+              throw "Project version '$pomVersion' is not supported. Expected X.Y.Z or X.Y.Z-<suffix>."
+            }
             $versionLabel = $pomVersion
-            $appVersion = $pomVersion
-            $changelogVersion = $pomVersion
-            $isPrerelease = $false
+            $appVersion = $Matches["core"]
+            $changelogVersion = $Matches["core"]
+            $isPrerelease = [string]::IsNullOrEmpty($Matches["suffix"]) -eq $false
           }
           "version_label=$versionLabel" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "app_version=$appVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 
 - Rail label PDFs now use the approved 4x2 label sheet geometry and larger label typography for the sequence, rail car code, destination counts, supporting item rows, and PASS/FUEL/BH fields.
 - Rail label route headers now print the DB train number, warehouse code, and load number together, for example `0526 BR 8000618166`.
+- Contextual GUI help now reads as an operator quick reference, emphasizing implemented shortcuts and high-value workflow details instead of basic computer-use instructions.
 - Project/module versions now target `1.8.0-SNAPSHOT` for the rail label and contextual help feature line.
 - Updated README documentation to reflect post-`1.7.6` hardening work, active issues `#42` and `#43`, and branch management expectations for documentation, optimization, and SRP refactors.
 - Release documentation now calls out architecture/SRP review as part of the pre-tag verification gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 
 - Rail label generation now accepts multiple train codes in one run using comma, whitespace, colon, slash, semicolon, or mixed delimiters, then renders one combined PDF.
 - The Rail Labels GUI now includes explicit printable-row checkboxes plus select-all, clear-all, invert, and multi-row keyboard toggling before PDF generation or printing.
+- GUI windows and tools now include contextual Help buttons that explain each workflow and its shortcuts.
 - Added a persisted `Developer mode` toggle under `Settings... -> Advanced Settings...` so internal users can opt into debug-oriented GUI behavior when needed.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 
 - Rail label PDFs now use the approved 4x2 label sheet geometry and larger label typography for the sequence, rail car code, destination counts, supporting item rows, and PASS/FUEL/BH fields.
 - Rail label route headers now print the DB train number, warehouse code, and load number together, for example `0526 BR 8000618166`.
+- Project/module versions now target `1.8.0-SNAPSHOT` for the rail label and contextual help feature line.
 - Updated README documentation to reflect post-`1.7.6` hardening work, active issues `#42` and `#43`, and branch management expectations for documentation, optimization, and SRP refactors.
 - Release documentation now calls out architecture/SRP review as part of the pre-tag verification gate.
 - `Tools -> Analyzers...` is now hidden unless developer mode is enabled, keeping the production operator menu focused on day-to-day workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 ### Changed
 
 - Rail label PDFs now use the approved 4x2 label sheet geometry and larger label typography for the sequence, rail car code, destination counts, supporting item rows, and PASS/FUEL/BH fields.
+- Rail label route headers now print the DB train number, warehouse code, and load number together, for example `0526 BR 8000618166`.
 - `Tools -> Analyzers...` is now hidden unless developer mode is enabled, keeping the production operator menu focused on day-to-day workflows.
 - GUI status/error messaging now surfaces extra debug context only when developer mode is enabled.
 - Release and operator docs now position the portable ZIP as the primary company-shareable package again, while keeping the installer path available for private/local use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 - Rail label generation now accepts multiple train codes in one run using comma, whitespace, colon, slash, semicolon, or mixed delimiters, then renders one combined PDF.
 - The Rail Labels GUI now includes explicit printable-row checkboxes plus select-all, clear-all, invert, and multi-row keyboard toggling before PDF generation or printing.
 - GUI windows and tools now include contextual Help buttons that explain each workflow and its shortcuts.
+- Added `docs/architecture-solid-audit.md` to capture the current SRP/SOLID audit, open GitHub issue context, verification baseline, and managed branch map for upcoming refactor work.
 - Added a persisted `Developer mode` toggle under `Settings... -> Advanced Settings...` so internal users can opt into debug-oriented GUI behavior when needed.
 
 ### Changed
 
 - Rail label PDFs now use the approved 4x2 label sheet geometry and larger label typography for the sequence, rail car code, destination counts, supporting item rows, and PASS/FUEL/BH fields.
 - Rail label route headers now print the DB train number, warehouse code, and load number together, for example `0526 BR 8000618166`.
+- Updated README documentation to reflect post-`1.7.6` hardening work, active issues `#42` and `#43`, and branch management expectations for documentation, optimization, and SRP refactors.
+- Release documentation now calls out architecture/SRP review as part of the pre-tag verification gate.
 - `Tools -> Analyzers...` is now hidden unless developer mode is enabled, keeping the production operator menu focused on day-to-day workflows.
 - GUI status/error messaging now surfaces extra debug context only when developer mode is enabled.
 - Release and operator docs now position the portable ZIP as the primary company-shareable package again, while keeping the installer path available for private/local use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Commit history is maintained with [Conventional Commits](https://www.conventiona
 
 ### Added
 
+- Rail label generation now accepts multiple train codes in one run using comma, whitespace, colon, slash, semicolon, or mixed delimiters, then renders one combined PDF.
+- The Rail Labels GUI now includes explicit printable-row checkboxes plus select-all, clear-all, invert, and multi-row keyboard toggling before PDF generation or printing.
 - Added a persisted `Developer mode` toggle under `Settings... -> Advanced Settings...` so internal users can opt into debug-oriented GUI behavior when needed.
 
 ### Changed
 
+- Rail label PDFs now use the approved 4x2 label sheet geometry and larger label typography for the sequence, rail car code, destination counts, supporting item rows, and PASS/FUEL/BH fields.
 - `Tools -> Analyzers...` is now hidden unless developer mode is enabled, keeping the production operator menu focused on day-to-day workflows.
 - GUI status/error messaging now surfaces extra debug context only when developer mode is enabled.
 - Release and operator docs now position the portable ZIP as the primary company-shareable package again, while keeping the installer path available for private/local use.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![Release Bundle](https://github.com/notzune/wms-pallet-tag-system/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/notzune/wms-pallet-tag-system/actions/workflows/release.yml)
 [![Javadoc Pages](https://github.com/notzune/wms-pallet-tag-system/actions/workflows/javadoc-pages.yml/badge.svg?branch=main)](https://github.com/notzune/wms-pallet-tag-system/actions/workflows/javadoc-pages.yml)
 [![API Docs](https://img.shields.io/badge/docs-javadoc-blue)](https://notzune.github.io/wms-pallet-tag-system/)
-![Version](https://img.shields.io/badge/version-1.7.6-blue)
+![Version](https://img.shields.io/badge/version-1.8.0--SNAPSHOT-blue)
 ![Java](https://img.shields.io/badge/java-17%2B-orange)
 ![License](https://img.shields.io/badge/license-Custom-green)
 
 Licensed under the terms in `LICENSE`.
 
 Production Java CLI and GUI for generating and printing Zebra ZPL pallet labels from Oracle WMS data.
-Current branch target: post-`1.7.6` hardening for rail labels, operator help, documentation, and focused SRP refactors.
+Current branch target: `1.8.0-SNAPSHOT` feature validation for rail labels, operator help, documentation, and focused SRP refactors.
 
 ## Versioning and History
 
@@ -230,7 +230,7 @@ Notes:
 - `build-jpackage-bundle.ps1` can optionally sign the app-image launcher(s) and the final installer via `-SigningMode signtool`
 - For standard certificate signing, pass one of `-CertificateThumbprint`, `-CertificateSubjectName`, or `-CertificatePath`
 - For Trusted Signing, pass the required `/dlib` and `/dmdf` values through `-AdditionalSignToolArgs`
-- Prerelease tags such as `v1.7.6-rc.2` are supported in CI and publish GitHub Releases marked as prereleases automatically
+- Prerelease tags such as `v1.8.0-rc.1` are supported in CI and publish GitHub Releases marked as prereleases automatically
 - The installer helper writes an MSI log and can uninstall an existing same-version install first when `-ReplaceExisting` is used
 - `uninstall-wms-tags.ps1` / `uninstall-wms-tags.bat` provide a direct uninstall path for packaged installs
 - GUI `Tools` / `Settings` now include `Update Manager...` and `Uninstall / Clean Install Prep...` actions for packaged installs
@@ -336,7 +336,7 @@ For clean-machine Windows installer validation in VirtualBox:
   -GuestUser <GUEST_USER> `
   -GuestPassword <GUEST_PASSWORD> `
   -OldInstallerPath C:\path\to\WMS` Pallet` Tag` System-1.7.4.exe `
-  -NewInstallerPath C:\path\to\WMS` Pallet` Tag` System-1.7.6.exe
+  -NewInstallerPath C:\path\to\WMS` Pallet` Tag` System-<version>.exe
 ```
 
 Outputs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Licensed under the terms in `LICENSE`.
 
 Production Java CLI and GUI for generating and printing Zebra ZPL pallet labels from Oracle WMS data.
-Current branch target: `1.7.6` prerelease validation.
+Current branch target: post-`1.7.6` hardening for rail labels, operator help, documentation, and focused SRP refactors.
 
 ## Versioning and History
 
@@ -20,6 +20,11 @@ Current branch target: `1.7.6` prerelease validation.
 - New release notes should be staged under `## [Unreleased]` before version cut/tagging.
 
 For open work and follow-up items, see the [GitHub issues tracker](https://github.com/notzune/wms-pallet-tag-system/issues).
+
+Active tracked work:
+
+- `#42` improves rail label readability, physical label-sheet documentation, multi-train input, combined PDF generation, and explicit printable-row selection.
+- `#43` adds contextual GUI help buttons and shared help-dialog behavior across operator views.
 
 ## Current Scope
 
@@ -52,6 +57,9 @@ Not implemented yet:
 - GUI workflow caches are site-scoped and thread-safe to prevent stale cross-site printer/site metadata reuse.
 - GUI preview selection refresh now snapshots the selected labels once per update cycle instead of rebuilding shipment/carrier subsets repeatedly.
 - Query and command execution paths remain hardened with prepared statements and argumentized process invocation patterns.
+- Architecture and SRP follow-up notes are tracked in [docs/architecture-solid-audit.md](docs/architecture-solid-audit.md).
+- Large Swing coordinators are refactor targets, not preferred homes for unrelated feature expansion.
+- New branch work should keep parser, data access, orchestration, rendering, and UI state responsibilities in separate classes with tests at the owning boundary.
 
 ## Prerequisites
 
@@ -591,6 +599,7 @@ Package-level documentation is maintained in every `package-info.java` under:
 
 Recent documentation maintenance:
 
+- `docs/architecture-solid-audit.md` captures the current SRP/SOLID audit, open issue context, verification baseline, and managed branch map
 - missing `package-info.java` coverage was filled for the newer `core` subpackages (`barcode`, `db`, `ems`, `label`, `labeling`, `location`, `sku`, `update`)
 - GUI settings/update/install maintenance responsibilities are now documented separately from the main frame through `MainSettingsDialog`
 - GUI print-task planning and artifact naming are now documented separately from workflow orchestration through `PrintTaskPlanner` and `ArtifactNameSupport`
@@ -606,6 +615,19 @@ Recent examples:
 - `DescriptionTextHeuristics` (shared description readability policy)
 - `PrtmstDescriptionColumnResolver` (cached PRTMST schema probing boundary)
 - `RailFootprintResolver` (deterministic candidate-consistency gate before pallet math)
+
+Documentation changes should follow the same boundary rules as code changes: update the README for user-facing workflows, the changelog for release-visible changes, ADRs for durable architecture decisions, and focused docs for operational or refactor guidance. Avoid duplicating long setup procedures across multiple files.
+
+## Branch and Refactor Management
+
+Use isolated worktrees under `.worktrees/` for work that can proceed independently from the main checkout. The current managed branch map is:
+
+- `docs/repo-documentation-solid-audit` - documentation refresh and SRP audit.
+- `refactor/srp-label-gui-frame` - planned extraction work for `LabelGuiFrame` and related Swing coordination responsibilities.
+- `refactor/srp-analyzer-loading` - planned consolidation of analyzer loading, dashboard loading state, and async data-provider boundaries.
+- `perf/code-optimization-baseline` - planned low-risk performance and maintainability cleanup after tests establish baseline behavior.
+
+Refactor branches must preserve behavior through tests before changing production code. Keep each branch narrow enough that a reviewer can evaluate one responsibility boundary at a time.
 
 ## CI Workflows
 

--- a/README.md
+++ b/README.md
@@ -457,12 +457,12 @@ Notes:
 ## Rail Print Command
 
 ```bash
-java -jar cli/target/cli-*.jar rail-print --train <TRAIN_ID> [OPTIONS]
+java -jar cli/target/cli-*.jar rail-print --train <TRAIN_ID>[,<TRAIN_ID>...] [OPTIONS]
 ```
 
 Options:
 
-- `--train <ID>` (required): full WMS train ID (example: `JC08312025`)
+- `--train <ID>` (required): one or more full WMS train IDs (example: `JC08312025`). Multiple train IDs may be separated with commas, spaces, colons, slashes, semicolons, or mixed delimiters.
 - `--output-dir <DIR>` (default `out/rail-print`)
 - `--print` (send generated PDF to default printer after confirmation)
 - `--template` (generate 10-position 4x2 alignment template PDF and exit)
@@ -476,22 +476,24 @@ Workflow:
 - Compute deterministic top-family percentages with largest-remainder rounding (stable ordering and 100% total)
 - Show preview table (`SEQ`, `VEHICLE`, `CAN`, `DOM`, `KEV`)
 - Confirm
-- Render direct letter-size rail card PDF (no Word mail merge dependency)
+- Render one direct letter-size rail card PDF for all requested trains (no Word mail merge dependency)
+- Use the approved 4x2 label-stock geometry and larger rail label typography for readability
 - Include `MISSING: <count>` warning on cards when any short codes are unresolved
 - Optionally print: tries configured rail printer first (`RAIL_DEFAULT_PRINTER_ID`), then opens system print dialog as fallback
 
 ## Rail Labels GUI Workflow
 
 - Open `gui`, then go to `Tools -> Rail Labels...`.
-- Enter train ID and click `Load Preview`.
+- Enter one or more train IDs and click `Load Preview`. Multiple train IDs may be separated with commas, spaces, colons, slashes, semicolons, or mixed delimiters.
 - Press `Ctrl+F` to trigger `Load Preview` from the keyboard while the workflow window is focused.
 - System pulls rail rows from WMS and resolves footprints by short code from WMS.
 - Preview includes:
-- Railcar table (`SEQ`, `VEHICLE`, `CAN`, `DOM`, `KEV`, `LOAD_NBR`)
+- Railcar table (`PRINT`, `TRAIN`, `SEQ`, `VEHICLE`, `CAN`, `DOM`, `KEV`, `LOAD_NBR`)
 - Railcar card preview panel (item lines + CAN/DOM/KEV + pass/fuel/BH fields)
 - Diagnostics panel (row counts and unresolved footprints)
+- All preview rows default to printable. Use the `PRINT` checkboxes, `Select All`, `Clear All`, `Invert`, or multi-select rows with Ctrl/Shift and press Space to control which rows are generated.
 - Rail print target dropdown only shows printers marked with the `RAIL` capability, plus `System default printer` and `Print to file`.
-- Click `Generate PDF` to produce a letter-size multi-card PDF.
+- Click `Generate PDF` to produce one letter-size multi-card PDF for the checked rows.
 - Click `Print` to generate PDF and send it to the selected rail printer, or keep `Print to file` selected to save only.
 
 ## Excel VBA Macro Helpers

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Key settings:
 - `SITE_<CODE>_SHIP_FROM_NAME`, `SITE_<CODE>_SHIP_FROM_ADDRESS`, `SITE_<CODE>_SHIP_FROM_CITY_STATE_ZIP`
 - `PRINTER_ROUTING_FILE=config/TBG3002/printer-routing.yaml`
 - `RAIL_DEFAULT_PRINTER_ID` (optional: rail PDF print target; printer ID from `printers.yaml`)
-- `RAIL_LABEL_CENTER_GAP_IN=0.125` (rail 2-column center gap, inches)
+- `RAIL_LABEL_CENTER_GAP_IN=0.1875` (rail 2-column center gap, inches)
 - `RAIL_LABEL_OFFSET_X_IN=0.02` (rail label grid X nudge, inches; + is right)
 - `RAIL_LABEL_OFFSET_Y_IN=0.02` (rail label grid Y nudge, inches; + is down)
 - `RIGHT_CLICK_COOLDOWN_MS=250` (GUI right-click copy/paste debounce)

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tbg.wms</groupId>
         <artifactId>wms-pallet-tag-system</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cli</artifactId>

--- a/cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupport.java
+++ b/cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupport.java
@@ -26,9 +26,46 @@ final class RailPrintCliSupport {
     }
 
     String buildPreviewText(RailWorkflowService.RailWorkflowResult result) {
+        return buildPreviewText(
+                List.of(result.getTrainId()),
+                result.getCards(),
+                result.getRawRows().size(),
+                result.getResolvedFootprints().size(),
+                result.getUnresolvedShortCodes(),
+                result.getMissingItemsInCards()
+        );
+    }
+
+    String buildPreviewText(RailWorkflowService.RailWorkflowBatchResult result) {
+        return buildPreviewText(
+                result.getTrainIds(),
+                result.getCards(),
+                result.getRawRows().size(),
+                result.getResolvedFootprints().size(),
+                result.getUnresolvedShortCodes(),
+                result.getMissingItemsInCards()
+        );
+    }
+
+    String fileNameToken(List<String> trainIds) {
+        if (trainIds == null || trainIds.isEmpty()) {
+            return "rail";
+        }
+        if (trainIds.size() == 1) {
+            return trainIds.get(0);
+        }
+        return trainIds.get(0) + "-plus-" + (trainIds.size() - 1);
+    }
+
+    private String buildPreviewText(List<String> trainIds,
+                                    List<RailCarCard> cards,
+                                    int rawRowCount,
+                                    int resolvedFootprintCount,
+                                    java.util.Set<String> unresolvedShortCodes,
+                                    java.util.Set<String> missingItemsInCards) {
         StringBuilder sb = new StringBuilder();
-        List<RailCarCard> cards = result.getCards();
         sb.append(System.lineSeparator());
+        sb.append("Train IDs: ").append(String.join(", ", trainIds)).append(System.lineSeparator());
         sb.append("SEQ   VEHICLE      CAN   DOM   KEV").append(System.lineSeparator());
         for (RailCarCard card : cards) {
             sb.append(String.format("%-5s %-12s %4d %4d %4d%n",
@@ -40,12 +77,12 @@ final class RailPrintCliSupport {
         }
         sb.append(System.lineSeparator());
         sb.append("Railcars: ").append(cards.size()).append(System.lineSeparator());
-        sb.append("WMS rows: ").append(result.getRawRows().size()).append(System.lineSeparator());
-        sb.append("Resolved footprints: ").append(result.getResolvedFootprints().size()).append(System.lineSeparator());
-        sb.append("Unresolved short codes: ").append(result.getUnresolvedShortCodes().size()).append(System.lineSeparator());
-        if (!result.getMissingItemsInCards().isEmpty()) {
+        sb.append("WMS rows: ").append(rawRowCount).append(System.lineSeparator());
+        sb.append("Resolved footprints: ").append(resolvedFootprintCount).append(System.lineSeparator());
+        sb.append("Unresolved short codes: ").append(unresolvedShortCodes.size()).append(System.lineSeparator());
+        if (!missingItemsInCards.isEmpty()) {
             sb.append("Missing in card math: ")
-                    .append(String.join(", ", result.getMissingItemsInCards()))
+                    .append(String.join(", ", missingItemsInCards))
                     .append(System.lineSeparator());
         }
         sb.append(System.lineSeparator());

--- a/cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCommand.java
+++ b/cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCommand.java
@@ -98,12 +98,13 @@ public final class RailPrintCommand implements Callable<Integer> {
             return 0;
         }
 
-        RailWorkflowService.RailWorkflowResult result;
+        List<String> trainIds = new RailTrainInputParser().parse(trainId);
+        RailWorkflowService.RailWorkflowBatchResult result;
 
         try (DbConnectionPool pool = new DbConnectionPool(config)) {
             RailDbRepository repository = new WmsRailDbRepository(new OracleDbQueryRepository(pool.getDataSource()));
             RailWorkflowService workflowService = new RailWorkflowService(repository);
-            result = workflowService.prepare(trainId);
+            result = workflowService.prepareAll(trainIds);
         }
 
         System.out.print(cliSupport.buildPreviewText(result));
@@ -114,7 +115,8 @@ public final class RailPrintCommand implements Callable<Integer> {
         }
 
         Files.createDirectories(outputDir);
-        String fileName = "rail-cards-" + result.getTrainId() + "-" + TS.format(LocalDateTime.now()) + ".pdf";
+        String fileName = "rail-cards-" + cliSupport.fileNameToken(result.getTrainIds()) + "-"
+                + TS.format(LocalDateTime.now()) + ".pdf";
         Path pdfPath = outputDir.resolve(fileName);
 
         RailCardRenderer renderer = cliSupport.railRenderer(config);

--- a/cli/src/test/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupportTest.java
+++ b/cli/src/test/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupportTest.java
@@ -66,6 +66,26 @@ final class RailPrintCliSupportTest {
         assertTrue(preview.contains("Missing in card math: 01830"));
     }
 
+    @Test
+    void buildPreviewTextIncludesMultiTrainSummary() throws Exception {
+        RailWorkflowService.RailWorkflowBatchResult result = batchResult(
+                List.of("JC08312025", "JC04152026"),
+                List.of(
+                        new RailCarCard("JC08312025", "142", "CAR-100", "LOAD-1",
+                                List.of(), 1, 2, 0, List.of(), List.of()),
+                        new RailCarCard("JC04152026", "200", "CAR-200", "LOAD-2",
+                                List.of(), 3, 4, 0, List.of(), List.of())
+                )
+        );
+
+        String preview = support.buildPreviewText(result);
+
+        assertTrue(preview.contains("Train IDs: JC08312025, JC04152026"));
+        assertTrue(preview.contains("Railcars: 2"));
+        assertTrue(preview.contains("CAR-100"));
+        assertTrue(preview.contains("CAR-200"));
+    }
+
     @SuppressWarnings("unchecked")
     private static RailWorkflowService.RailWorkflowResult workflowResult(
             List<RailCarCard> cards,
@@ -86,6 +106,27 @@ final class RailPrintCliSupportTest {
                 resolvedFootprints,
                 unresolvedShortCodes,
                 missingItemsInCards
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RailWorkflowService.RailWorkflowBatchResult batchResult(
+            List<String> trainIds,
+            List<RailCarCard> cards
+    ) throws Exception {
+        Constructor<RailWorkflowService.RailWorkflowBatchResult> ctor =
+                (Constructor<RailWorkflowService.RailWorkflowBatchResult>)
+                        RailWorkflowService.RailWorkflowBatchResult.class.getDeclaredConstructors()[0];
+        ctor.setAccessible(true);
+        return ctor.newInstance(
+                trainIds,
+                List.of(),
+                List.of(),
+                List.of(),
+                cards,
+                Map.of(),
+                Set.of(),
+                Set.of()
         );
     }
 }

--- a/config/wms-tags.env.example
+++ b/config/wms-tags.env.example
@@ -21,6 +21,6 @@ PRINTER_ROUTING_FILE=config/TBG3002/printer-routing.yaml
 # Optional rail PDF print target override (printers.yaml ID):
 #RAIL_DEFAULT_PRINTER_ID=RAIL_OFFICE
 # Rail label PDF calibration (inches):
-RAIL_LABEL_CENTER_GAP_IN=0.125
+RAIL_LABEL_CENTER_GAP_IN=0.1875
 RAIL_LABEL_OFFSET_X_IN=0.02
 RAIL_LABEL_OFFSET_Y_IN=0.02

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tbg.wms</groupId>
         <artifactId>wms-pallet-tag-system</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/src/main/java/com/tbg/wms/core/AppConfig.java
+++ b/core/src/main/java/com/tbg/wms/core/AppConfig.java
@@ -306,7 +306,7 @@ public final class AppConfig {
     /**
      * Horizontal center-gap between the two rail label columns, in inches.
      *
-     * @return center gap from {@code RAIL_LABEL_CENTER_GAP_IN} (default: {@code 0.125})
+     * @return center gap from {@code RAIL_LABEL_CENTER_GAP_IN} (default: {@code 0.1875})
      */
     public double railLabelCenterGapInches() {
         return printRuntimeSupport.railLabelCenterGapInches();

--- a/core/src/main/java/com/tbg/wms/core/PrintRuntimeConfigSupport.java
+++ b/core/src/main/java/com/tbg/wms/core/PrintRuntimeConfigSupport.java
@@ -27,7 +27,7 @@ final class PrintRuntimeConfigSupport {
     }
 
     double railLabelCenterGapInches() {
-        return valueSupport.parseDouble("RAIL_LABEL_CENTER_GAP_IN", "0.125");
+        return valueSupport.parseDouble("RAIL_LABEL_CENTER_GAP_IN", "0.1875");
     }
 
     double railLabelOffsetXInches() {

--- a/core/src/main/java/com/tbg/wms/core/barcode/BarcodeZplBuilder.java
+++ b/core/src/main/java/com/tbg/wms/core/barcode/BarcodeZplBuilder.java
@@ -83,10 +83,9 @@ public final class BarcodeZplBuilder {
         int blockWidth = estimatedBarcodeWidth;
         int blockHeight = request.getBarcodeHeight() + textHeight;
         if (landscape) {
-            int rotatedWidth = blockHeight;
-            int rotatedHeight = blockWidth;
-            blockWidth = rotatedWidth;
-            blockHeight = rotatedHeight;
+            int unrotatedWidth = blockWidth;
+            blockWidth = blockHeight;
+            blockHeight = unrotatedWidth;
         }
 
         int centeredX = centerWithinSafeArea(

--- a/core/src/main/java/com/tbg/wms/core/rail/RailCarCard.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailCarCard.java
@@ -15,6 +15,7 @@ public final class RailCarCard {
     private final String sequence;
     private final String vehicleId;
     private final String loadNumbers;
+    private final String routeHeader;
     private final List<RailStopRecord.ItemQuantity> itemLines;
     private final int canPallets;
     private final int domPallets;
@@ -32,10 +33,37 @@ public final class RailCarCard {
                        int kevPallets,
                        List<String> topFamilies,
                        List<String> missingFootprintItems) {
+        this(
+                trainId,
+                sequence,
+                vehicleId,
+                loadNumbers,
+                loadNumbers,
+                itemLines,
+                canPallets,
+                domPallets,
+                kevPallets,
+                topFamilies,
+                missingFootprintItems
+        );
+    }
+
+    public RailCarCard(String trainId,
+                       String sequence,
+                       String vehicleId,
+                       String loadNumbers,
+                       String routeHeader,
+                       List<RailStopRecord.ItemQuantity> itemLines,
+                       int canPallets,
+                       int domPallets,
+                       int kevPallets,
+                       List<String> topFamilies,
+                       List<String> missingFootprintItems) {
         this.trainId = normalize(trainId);
         this.sequence = normalize(sequence);
         this.vehicleId = normalize(vehicleId);
         this.loadNumbers = normalize(loadNumbers);
+        this.routeHeader = normalize(routeHeader);
         this.itemLines = Collections.unmodifiableList(new ArrayList<>(itemLines));
         this.canPallets = canPallets;
         this.domPallets = domPallets;
@@ -62,6 +90,10 @@ public final class RailCarCard {
 
     public String getLoadNumbers() {
         return loadNumbers;
+    }
+
+    public String getRouteHeader() {
+        return routeHeader;
     }
 
     public List<RailStopRecord.ItemQuantity> getItemLines() {

--- a/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
@@ -12,6 +12,7 @@ import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,22 +21,14 @@ import java.util.Objects;
  */
 public final class RailCardRenderer {
     private static final PDRectangle PAGE_SIZE = PDRectangle.LETTER;
-    private static final int GRID_COLS = 2;
-    private static final int GRID_ROWS = 5;
-    private static final float POINTS_PER_INCH = 72f;
-    private static final float LABEL_WIDTH = 4.0f * POINTS_PER_INCH;
-    private static final float LABEL_HEIGHT = 2.0f * POINTS_PER_INCH;
-    private static final float GRID_GAP_Y = 0f;
-    private static final float HEADER_FONT_SIZE = 8.5f;
-    private static final float BODY_FONT_SIZE = 6.3f;
-    private static final float LINE_HEIGHT = 8.0f;
+    private static final float BORDER_WIDTH = 0.5f;
+    private static final float TEXT_INSET = 7f;
+    private static final float FOOTER_Y_OFFSET = 8f;
     private static final int ITEMS_PER_CARD = 5;
-    private final float gridGapX;
-    private final float pageMarginX;
-    private final float pageMarginY;
+    private final RailLabelSheetLayout layout;
 
     public RailCardRenderer() {
-        this(0.125f, 0f, 0f);
+        this.layout = RailLabelSheetLayout.defaultLayout();
     }
 
     /**
@@ -46,13 +39,7 @@ public final class RailCardRenderer {
      * @param offsetYInches   positive moves grid down
      */
     public RailCardRenderer(float centerGapInches, float offsetXInches, float offsetYInches) {
-        this.gridGapX = centerGapInches * POINTS_PER_INCH;
-        this.pageMarginX =
-                ((PAGE_SIZE.getWidth() - ((GRID_COLS * LABEL_WIDTH) + ((GRID_COLS - 1) * gridGapX))) / 2.0f)
-                        + (offsetXInches * POINTS_PER_INCH);
-        this.pageMarginY =
-                ((PAGE_SIZE.getHeight() - ((GRID_ROWS * LABEL_HEIGHT) + ((GRID_ROWS - 1) * GRID_GAP_Y))) / 2.0f)
-                        + (offsetYInches * POINTS_PER_INCH);
+        this.layout = RailLabelSheetLayout.calibrated(centerGapInches, offsetXInches, offsetYInches);
     }
 
     /**
@@ -79,7 +66,7 @@ public final class RailCardRenderer {
                     PDPage page = new PDPage(PAGE_SIZE);
                     document.addPage(page);
                     try (PDPageContentStream content = new PDPageContentStream(document, page)) {
-                        for (int slot = 0; slot < GRID_COLS * GRID_ROWS && index < cards.size(); slot++, index++) {
+                        for (int slot = 0; slot < layout.slotsPerPage() && index < cards.size(); slot++, index++) {
                             drawCard(content, cards.get(index), slot);
                         }
                     }
@@ -107,7 +94,7 @@ public final class RailCardRenderer {
             PDPage page = new PDPage(PAGE_SIZE);
             document.addPage(page);
             try (PDPageContentStream content = new PDPageContentStream(document, page)) {
-                for (int slot = 0; slot < GRID_COLS * GRID_ROWS; slot++) {
+                for (int slot = 0; slot < layout.slotsPerPage(); slot++) {
                     drawAlignmentSlot(content, slot);
                 }
             }
@@ -117,106 +104,120 @@ public final class RailCardRenderer {
     }
 
     private void drawAlignmentSlot(PDPageContentStream content, int slot) throws IOException {
-        Rect rect = slotRect(slot);
-        float left = rect.left;
-        float top = rect.top;
-        float bottom = rect.bottom;
+        RailLabelSheetLayout.LabelSlot rect = layout.slot(slot);
+        float left = rect.left();
+        float top = rect.top();
+        float bottom = rect.bottom();
 
-        content.addRect(left, bottom, LABEL_WIDTH, LABEL_HEIGHT);
+        content.addRect(left, bottom, rect.width(), rect.height());
         content.stroke();
 
         float inset = 10f;
-        content.addRect(left + inset, bottom + inset, LABEL_WIDTH - (2 * inset), LABEL_HEIGHT - (2 * inset));
+        content.addRect(left + inset, bottom + inset, rect.width() - (2 * inset), rect.height() - (2 * inset));
         content.stroke();
 
-        float cx = left + (LABEL_WIDTH / 2f);
-        float cy = bottom + (LABEL_HEIGHT / 2f);
+        float cx = left + (rect.width() / 2f);
+        float cy = bottom + (rect.height() / 2f);
         content.moveTo(cx - 9f, cy);
         content.lineTo(cx + 9f, cy);
         content.moveTo(cx, cy - 9f);
         content.lineTo(cx, cy + 9f);
         content.stroke();
 
-        int row = (slot / GRID_COLS) + 1;
-        int col = (slot % GRID_COLS) + 1;
+        int row = (slot / 2) + 1;
+        int col = (slot % 2) + 1;
         String label = "POS " + row + "-" + col + " (slot " + (slot + 1) + ")";
         writeText(content, PDType1Font.HELVETICA_BOLD, 9f, left + 8f, top - 14f, label);
         writeText(content, PDType1Font.HELVETICA, 7f, left + 8f, top - 26f,
-                "4.00in x 2.00in | center gap=" + (gridGapX / POINTS_PER_INCH) + "in");
+                "4.00in x 2.00in rail label");
     }
 
     private void drawCard(PDPageContentStream content, RailCarCard card, int slot) throws IOException {
-        Rect rect = slotRect(slot);
-        float left = rect.left;
-        float top = rect.top;
-        float bottom = rect.bottom;
+        RailLabelSheetLayout.LabelSlot rect = layout.slot(slot);
+        float left = rect.left();
+        float top = rect.top();
+        float bottom = rect.bottom();
+        float right = left + rect.width();
 
-        content.addRect(left, bottom, LABEL_WIDTH, LABEL_HEIGHT);
+        content.setLineWidth(BORDER_WIDTH);
+        content.addRect(left, bottom, rect.width(), rect.height());
         content.stroke();
 
-        float textX = left + 7f;
-        float y = top - 11f;
+        float textLeft = left + TEXT_INSET;
+        float textRight = right - TEXT_INSET;
+        float centerX = left + (rect.width() / 2f);
 
-        writeText(content, PDType1Font.HELVETICA_BOLD, HEADER_FONT_SIZE,
-                textX, y, safe(card.getSequence()) + "      " + safe(card.getVehicleId()));
-        y -= LINE_HEIGHT;
+        writeUnderlinedText(content, PDType1Font.HELVETICA_BOLD_OBLIQUE, RailLabelTypography.SEQUENCE_SIZE,
+                textLeft, top - 22f, safe(card.getSequence()));
+        writeRightAlignedUnderlinedText(content, PDType1Font.HELVETICA_BOLD_OBLIQUE, RailLabelTypography.VEHICLE_SIZE,
+                textRight, top - 27f, safe(card.getVehicleId()));
 
+        float supportY = top - 39f;
         if (!card.getLoadNumbers().isBlank()) {
-            writeText(content, PDType1Font.HELVETICA, BODY_FONT_SIZE, textX, y, "LOAD: " + card.getLoadNumbers());
-            y -= LINE_HEIGHT;
+            writeText(content, PDType1Font.HELVETICA_OBLIQUE, RailLabelTypography.ROUTE_HEADER_SIZE,
+                    textLeft, supportY, card.getLoadNumbers());
+            supportY -= 10f;
         }
-        writeText(content, PDType1Font.COURIER_BOLD, BODY_FONT_SIZE, textX, y, "ITEM LIST");
-        y -= LINE_HEIGHT;
 
+        float itemFontSize = itemFontSize(card.getItemLines().size());
         int itemCount = Math.min(ITEMS_PER_CARD, card.getItemLines().size());
         for (int i = 0; i < itemCount; i++) {
             RailStopRecord.ItemQuantity item = card.getItemLines().get(i);
-            String line = String.format("%-10s %6d", safe(item.getItemNumber()), item.getCases());
-            writeText(content, PDType1Font.COURIER, BODY_FONT_SIZE, textX, y, line);
-            y -= LINE_HEIGHT;
+            String line = safe(item.getItemNumber()) + " " + item.getCases();
+            writeText(content, PDType1Font.HELVETICA, itemFontSize, textLeft, supportY, line);
+            supportY -= itemFontSize + 2f;
         }
 
         if (card.getItemLines().size() > ITEMS_PER_CARD) {
             int remaining = card.getItemLines().size() - ITEMS_PER_CARD;
-            writeText(content, PDType1Font.HELVETICA_OBLIQUE, BODY_FONT_SIZE, textX, y,
-                    "... " + remaining + " more item(s)");
-            y -= LINE_HEIGHT;
+            writeText(content, PDType1Font.HELVETICA_OBLIQUE, RailLabelTypography.MIN_ITEM_SIZE,
+                    textLeft, supportY, "... " + remaining + " more");
         }
 
-        y -= 2f;
-        writeText(content, PDType1Font.HELVETICA_BOLD, BODY_FONT_SIZE, textX, y, "CAN: " + card.getCanPallets());
-        y -= LINE_HEIGHT;
-        writeText(content, PDType1Font.HELVETICA_BOLD, BODY_FONT_SIZE, textX, y, "DOM: " + card.getDomPallets());
-        y -= LINE_HEIGHT;
-        writeText(content, PDType1Font.HELVETICA_BOLD, BODY_FONT_SIZE, textX, y, "KEV: " + card.getKevPallets());
-        y -= LINE_HEIGHT;
-
-        if (!card.getTopFamilies().isEmpty()) {
-            writeText(content, PDType1Font.HELVETICA, BODY_FONT_SIZE, textX, y,
-                    "TOP: " + String.join(" ", card.getTopFamilies()));
-            y -= LINE_HEIGHT;
+        List<DestinationCount> counts = destinationCounts(card);
+        if (!counts.isEmpty()) {
+            writeCenteredText(content, PDType1Font.HELVETICA_BOLD, RailLabelTypography.PRIMARY_DESTINATION_SIZE,
+                    centerX, bottom + 63f, counts.get(0).display());
+        }
+        if (counts.size() > 1) {
+            writeCenteredUnderlinedText(content, PDType1Font.HELVETICA_BOLD_OBLIQUE,
+                    RailLabelTypography.SECONDARY_DESTINATION_SIZE, centerX, bottom + 40f, counts.get(1).display());
         }
 
         if (!card.getMissingFootprintItems().isEmpty()) {
-            writeText(content, PDType1Font.HELVETICA_OBLIQUE, BODY_FONT_SIZE, textX, y,
-                    "MISSING: " + card.getMissingFootprintItems().size());
+            writeText(content, PDType1Font.HELVETICA_OBLIQUE, RailLabelTypography.MIN_ITEM_SIZE,
+                    textLeft, bottom + 22f, "MISSING: " + card.getMissingFootprintItems().size());
         }
 
-        writeText(content, PDType1Font.HELVETICA, BODY_FONT_SIZE, textX, bottom + 8f,
-                "PASS: ______   FUEL: ______   BH: ______");
-    }
-
-    private Rect slotRect(int slot) {
-        int row = slot / GRID_COLS;
-        int col = slot % GRID_COLS;
-        float left = pageMarginX + (col * (LABEL_WIDTH + gridGapX));
-        float top = PAGE_SIZE.getHeight() - pageMarginY - (row * (LABEL_HEIGHT + GRID_GAP_Y));
-        float bottom = top - LABEL_HEIGHT;
-        return new Rect(left, top, bottom);
+        drawFooterField(content, textLeft, bottom + FOOTER_Y_OFFSET, "PASS:");
+        drawFooterField(content, left + 102f, bottom + FOOTER_Y_OFFSET, "FUEL:");
+        drawFooterField(content, left + 198f, bottom + FOOTER_Y_OFFSET, "BH:");
     }
 
     private String safe(String value) {
         return value == null ? "" : value;
+    }
+
+    private float itemFontSize(int itemRows) {
+        if (itemRows <= ITEMS_PER_CARD) {
+            return RailLabelTypography.ITEM_SIZE;
+        }
+        float shrink = (itemRows - ITEMS_PER_CARD) * 0.4f;
+        return Math.max(RailLabelTypography.MIN_ITEM_SIZE, RailLabelTypography.ITEM_SIZE - shrink);
+    }
+
+    private List<DestinationCount> destinationCounts(RailCarCard card) {
+        List<DestinationCount> counts = new ArrayList<>(3);
+        if (card.getCanPallets() > 0) {
+            counts.add(new DestinationCount("CAN", card.getCanPallets()));
+        }
+        if (card.getDomPallets() > 0) {
+            counts.add(new DestinationCount("DOM", card.getDomPallets()));
+        }
+        if (card.getKevPallets() > 0) {
+            counts.add(new DestinationCount("KEV", card.getKevPallets()));
+        }
+        return counts;
     }
 
     private void writeText(PDPageContentStream content,
@@ -232,15 +233,75 @@ public final class RailCardRenderer {
         content.endText();
     }
 
-    private static final class Rect {
-        private final float left;
-        private final float top;
-        private final float bottom;
+    private void writeUnderlinedText(PDPageContentStream content,
+                                     PDType1Font font,
+                                     float fontSize,
+                                     float x,
+                                     float y,
+                                     String text) throws IOException {
+        writeText(content, font, fontSize, x, y, text);
+        underline(content, font, fontSize, x, y, text);
+    }
 
-        private Rect(float left, float top, float bottom) {
-            this.left = left;
-            this.top = top;
-            this.bottom = bottom;
+    private void writeRightAlignedUnderlinedText(PDPageContentStream content,
+                                                PDType1Font font,
+                                                float fontSize,
+                                                float right,
+                                                float y,
+                                                String text) throws IOException {
+        float width = textWidth(font, fontSize, text);
+        writeUnderlinedText(content, font, fontSize, right - width, y, text);
+    }
+
+    private void writeCenteredText(PDPageContentStream content,
+                                   PDType1Font font,
+                                   float fontSize,
+                                   float centerX,
+                                   float y,
+                                   String text) throws IOException {
+        float width = textWidth(font, fontSize, text);
+        writeText(content, font, fontSize, centerX - (width / 2f), y, text);
+    }
+
+    private void writeCenteredUnderlinedText(PDPageContentStream content,
+                                             PDType1Font font,
+                                             float fontSize,
+                                             float centerX,
+                                             float y,
+                                             String text) throws IOException {
+        float width = textWidth(font, fontSize, text);
+        float x = centerX - (width / 2f);
+        writeUnderlinedText(content, font, fontSize, x, y, text);
+    }
+
+    private void drawFooterField(PDPageContentStream content, float x, float y, String label) throws IOException {
+        writeText(content, PDType1Font.HELVETICA_BOLD, RailLabelTypography.FOOTER_SIZE, x, y, label);
+        float labelWidth = textWidth(PDType1Font.HELVETICA_BOLD, RailLabelTypography.FOOTER_SIZE, label);
+        float underlineStart = x + labelWidth + 2f;
+        content.moveTo(underlineStart, y - 1f);
+        content.lineTo(underlineStart + 36f, y - 1f);
+        content.stroke();
+    }
+
+    private void underline(PDPageContentStream content,
+                           PDType1Font font,
+                           float fontSize,
+                           float x,
+                           float y,
+                           String text) throws IOException {
+        content.moveTo(x, y - 2f);
+        content.lineTo(x + textWidth(font, fontSize, text) + 2f, y - 2f);
+        content.stroke();
+    }
+
+    private float textWidth(PDType1Font font, float fontSize, String text) throws IOException {
+        String safeText = text == null ? "" : text;
+        return font.getStringWidth(safeText) / 1000f * fontSize;
+    }
+
+    private record DestinationCount(String label, int count) {
+        private String display() {
+            return label + ":" + count;
         }
     }
 }

--- a/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
@@ -160,18 +160,11 @@ public final class RailCardRenderer {
         }
 
         float itemFontSize = itemFontSize(card.getItemLines().size());
-        int itemCount = Math.min(ITEMS_PER_CARD, card.getItemLines().size());
-        for (int i = 0; i < itemCount; i++) {
+        for (int i = 0; i < card.getItemLines().size(); i++) {
             RailStopRecord.ItemQuantity item = card.getItemLines().get(i);
             String line = safe(item.getItemNumber()) + " " + item.getCases();
             writeText(content, PDType1Font.HELVETICA, itemFontSize, textLeft, supportY, line);
             supportY -= itemFontSize + 2f;
-        }
-
-        if (card.getItemLines().size() > ITEMS_PER_CARD) {
-            int remaining = card.getItemLines().size() - ITEMS_PER_CARD;
-            writeText(content, PDType1Font.HELVETICA_OBLIQUE, RailLabelTypography.MIN_ITEM_SIZE,
-                    textLeft, supportY, "... " + remaining + " more");
         }
 
         List<DestinationCount> counts = destinationCounts(card);

--- a/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java
@@ -153,9 +153,9 @@ public final class RailCardRenderer {
                 textRight, top - 27f, safe(card.getVehicleId()));
 
         float supportY = top - 39f;
-        if (!card.getLoadNumbers().isBlank()) {
+        if (!card.getRouteHeader().isBlank()) {
             writeText(content, PDType1Font.HELVETICA_OBLIQUE, RailLabelTypography.ROUTE_HEADER_SIZE,
-                    textLeft, supportY, card.getLoadNumbers());
+                    textLeft, supportY, card.getRouteHeader());
             supportY -= 10f;
         }
 

--- a/core/src/main/java/com/tbg/wms/core/rail/RailLabelSheetLayout.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailLabelSheetLayout.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.core.rail;
+
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+
+/**
+ * Physical sheet layout for rail labels.
+ *
+ * <p>The rail label stock is a letter-sized 8.5 inch by 11 inch portrait sheet
+ * with two columns and five rows of 4.0 inch by 2.0 inch labels.</p>
+ *
+ * <p>Approved physical measurements:</p>
+ *
+ * <pre>
+ * Page width       = 8.5"
+ * Page height      = 11.0"
+ * Label width      = 4.0"
+ * Label height     = 2.0"
+ * Left margin      = 5/32" = 0.15625"
+ * Right margin     = 5/32" = 0.15625"
+ * Top margin       = 0.5"
+ * Bottom margin    = 0.5"
+ * Center gap       = 3/16" = 0.1875"
+ *
+ * Horizontal check = (4.0 * 2) + 0.1875 + (0.15625 * 2) = 8.5
+ * Vertical check   = (2.0 * 5) + (0.5 * 2) = 11.0
+ * </pre>
+ *
+ * <p>PDFBox uses points, so all rendering coordinates are derived from inches at runtime:</p>
+ *
+ * <pre>
+ * points = inches * 72
+ * </pre>
+ *
+ * <p>For 300 DPI print-preview comparisons:</p>
+ *
+ * <pre>
+ * Page:              8.5 * 300 = 2550 px, 11 * 300 = 3300 px
+ * Label:             4.0 * 300 = 1200 px, 2.0 * 300 = 600 px
+ * Left/right margin: 0.15625 * 300 = 46.875 px, rounded 47 px
+ * Center gap:        0.1875 * 300 = 56.25 px, rounded 56 px
+ * Top/bottom margin: 0.5 * 300 = 150 px
+ * </pre>
+ *
+ * <p>This class deliberately owns only media geometry. It does not know about rail-card data,
+ * fonts, PDF content streams, print routing, or Swing UI state.</p>
+ */
+public final class RailLabelSheetLayout {
+    private static final float POINTS_PER_INCH = 72f;
+    private static final float PAGE_WIDTH_INCHES = 8.5f;
+    private static final float PAGE_HEIGHT_INCHES = 11.0f;
+    private static final float LABEL_WIDTH_INCHES = 4.0f;
+    private static final float LABEL_HEIGHT_INCHES = 2.0f;
+    private static final float LEFT_MARGIN_INCHES = 0.15625f;
+    private static final float TOP_MARGIN_INCHES = 0.5f;
+    private static final float CENTER_GAP_INCHES = 0.1875f;
+    private static final int COLUMNS = 2;
+    private static final int ROWS = 5;
+
+    private final float pageWidthPoints;
+    private final float pageHeightPoints;
+    private final float labelWidthPoints;
+    private final float labelHeightPoints;
+    private final float leftMarginPoints;
+    private final float topMarginPoints;
+    private final float horizontalGapPoints;
+
+    private RailLabelSheetLayout(float pageWidthPoints,
+                                 float pageHeightPoints,
+                                 float labelWidthPoints,
+                                 float labelHeightPoints,
+                                 float leftMarginPoints,
+                                 float topMarginPoints,
+                                 float horizontalGapPoints) {
+        this.pageWidthPoints = pageWidthPoints;
+        this.pageHeightPoints = pageHeightPoints;
+        this.labelWidthPoints = labelWidthPoints;
+        this.labelHeightPoints = labelHeightPoints;
+        this.leftMarginPoints = leftMarginPoints;
+        this.topMarginPoints = topMarginPoints;
+        this.horizontalGapPoints = horizontalGapPoints;
+    }
+
+    public static RailLabelSheetLayout defaultLayout() {
+        return new RailLabelSheetLayout(
+                inchesToPoints(PAGE_WIDTH_INCHES),
+                inchesToPoints(PAGE_HEIGHT_INCHES),
+                inchesToPoints(LABEL_WIDTH_INCHES),
+                inchesToPoints(LABEL_HEIGHT_INCHES),
+                inchesToPoints(LEFT_MARGIN_INCHES),
+                inchesToPoints(TOP_MARGIN_INCHES),
+                inchesToPoints(CENTER_GAP_INCHES)
+        );
+    }
+
+    static RailLabelSheetLayout calibrated(float centerGapInches, float offsetXInches, float offsetYInches) {
+        float labelWidth = inchesToPoints(LABEL_WIDTH_INCHES);
+        float gap = inchesToPoints(centerGapInches);
+        float pageWidth = inchesToPoints(PAGE_WIDTH_INCHES);
+        float centeredLeftMargin = (pageWidth - ((COLUMNS * labelWidth) + ((COLUMNS - 1) * gap))) / 2.0f;
+        return new RailLabelSheetLayout(
+                pageWidth,
+                inchesToPoints(PAGE_HEIGHT_INCHES),
+                labelWidth,
+                inchesToPoints(LABEL_HEIGHT_INCHES),
+                centeredLeftMargin + inchesToPoints(offsetXInches),
+                inchesToPoints(TOP_MARGIN_INCHES) + inchesToPoints(offsetYInches),
+                gap
+        );
+    }
+
+    public PDRectangle pageSize() {
+        return new PDRectangle(pageWidthPoints, pageHeightPoints);
+    }
+
+    public float pageWidthPoints() {
+        return pageWidthPoints;
+    }
+
+    public float pageHeightPoints() {
+        return pageHeightPoints;
+    }
+
+    public float labelWidthPoints() {
+        return labelWidthPoints;
+    }
+
+    public float labelHeightPoints() {
+        return labelHeightPoints;
+    }
+
+    public int slotsPerPage() {
+        return COLUMNS * ROWS;
+    }
+
+    public LabelSlot slot(int index) {
+        if (index < 0 || index >= slotsPerPage()) {
+            throw new IllegalArgumentException("Label slot index out of range: " + index);
+        }
+        int row = index / COLUMNS;
+        int column = index % COLUMNS;
+        float left = leftMarginPoints + (column * (labelWidthPoints + horizontalGapPoints));
+        float top = pageHeightPoints - topMarginPoints - (row * labelHeightPoints);
+        float bottom = top - labelHeightPoints;
+        return new LabelSlot(left, top, bottom, labelWidthPoints, labelHeightPoints);
+    }
+
+    static float inchesToPoints(float inches) {
+        return inches * POINTS_PER_INCH;
+    }
+
+    public record LabelSlot(float left, float top, float bottom, float width, float height) {
+    }
+}

--- a/core/src/main/java/com/tbg/wms/core/rail/RailLabelTypography.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailLabelTypography.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.core.rail;
+
+/**
+ * Typography constants for 4 inch by 2 inch rail labels.
+ */
+final class RailLabelTypography {
+    static final float SEQUENCE_SIZE = 18f;
+    static final float VEHICLE_SIZE = 30f;
+    static final float ROUTE_HEADER_SIZE = 8f;
+    static final float DOOR_LANE_SIZE = 9f;
+    static final float ITEM_SIZE = 8f;
+    static final float MIN_ITEM_SIZE = 6f;
+    static final float PRIMARY_DESTINATION_SIZE = 30f;
+    static final float SECONDARY_DESTINATION_SIZE = 22f;
+    static final float FOOTER_SIZE = 8f;
+
+    private RailLabelTypography() {
+    }
+}

--- a/core/src/main/java/com/tbg/wms/core/rail/RailTrainInputParser.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailTrainInputParser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.core.rail;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Parses operator-entered rail train codes into normalized, ordered train IDs.
+ */
+public final class RailTrainInputParser {
+    private static final Pattern DELIMITERS = Pattern.compile("[,\\s:/;]+");
+
+    /**
+     * Splits train-code input on comma, whitespace, colon, slash, semicolon, or any combination.
+     *
+     * @param input operator-entered train-code text
+     * @return uppercase train IDs in first-seen order
+     */
+    public List<String> parse(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("At least one train ID is required.");
+        }
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        for (String token : DELIMITERS.split(input.trim())) {
+            String normalized = token.trim().toUpperCase(Locale.ROOT);
+            if (!normalized.isEmpty()) {
+                values.add(normalized);
+            }
+        }
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("At least one train ID is required.");
+        }
+        return List.copyOf(values);
+    }
+}

--- a/core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java
@@ -74,6 +74,51 @@ public final class RailWorkflowService {
         );
     }
 
+    /**
+     * Builds print-ready cards for multiple trains in the caller-provided order.
+     *
+     * @param trainIds train identifiers
+     * @return deterministic combined workflow result
+     */
+    public RailWorkflowBatchResult prepareAll(List<String> trainIds) {
+        if (trainIds == null || trainIds.isEmpty()) {
+            throw new IllegalArgumentException("At least one train ID is required.");
+        }
+
+        List<String> normalizedTrainIds = new ArrayList<>(trainIds.size());
+        List<RailWorkflowResult> results = new ArrayList<>(trainIds.size());
+        List<RailStopRecord> rawRows = new ArrayList<>();
+        List<RailCarAggregate> aggregates = new ArrayList<>();
+        List<RailCarCard> cards = new ArrayList<>();
+        Map<String, RailFamilyFootprint> resolvedFootprints = new LinkedHashMap<>();
+        Set<String> unresolvedShortCodes = new TreeSet<>();
+        Set<String> missingItemsInCards = new TreeSet<>();
+
+        for (String trainId : trainIds) {
+            String normalizedTrainId = normalizeTrainId(trainId);
+            RailWorkflowResult result = prepare(normalizedTrainId);
+            normalizedTrainIds.add(normalizedTrainId);
+            results.add(result);
+            rawRows.addAll(result.getRawRows());
+            aggregates.addAll(result.getAggregates());
+            cards.addAll(result.getCards());
+            resolvedFootprints.putAll(result.getResolvedFootprints());
+            unresolvedShortCodes.addAll(result.getUnresolvedShortCodes());
+            missingItemsInCards.addAll(result.getMissingItemsInCards());
+        }
+
+        return new RailWorkflowBatchResult(
+                normalizedTrainIds,
+                results,
+                rawRows,
+                aggregates,
+                cards,
+                resolvedFootprints,
+                unresolvedShortCodes,
+                missingItemsInCards
+        );
+    }
+
     private RailCarCard buildCard(String trainId,
                                   RailCarAggregate aggregate,
                                   Map<String, RailFamilyFootprint> footprints,
@@ -145,6 +190,70 @@ public final class RailWorkflowService {
 
         public String getTrainId() {
             return trainId;
+        }
+
+        public List<RailStopRecord> getRawRows() {
+            return rawRows;
+        }
+
+        public List<RailCarAggregate> getAggregates() {
+            return aggregates;
+        }
+
+        public List<RailCarCard> getCards() {
+            return cards;
+        }
+
+        public Map<String, RailFamilyFootprint> getResolvedFootprints() {
+            return resolvedFootprints;
+        }
+
+        public Set<String> getUnresolvedShortCodes() {
+            return unresolvedShortCodes;
+        }
+
+        public Set<String> getMissingItemsInCards() {
+            return missingItemsInCards;
+        }
+    }
+
+    /**
+     * Immutable combined output for multi-train rail label preparation.
+     */
+    public static final class RailWorkflowBatchResult {
+        private final List<String> trainIds;
+        private final List<RailWorkflowResult> results;
+        private final List<RailStopRecord> rawRows;
+        private final List<RailCarAggregate> aggregates;
+        private final List<RailCarCard> cards;
+        private final Map<String, RailFamilyFootprint> resolvedFootprints;
+        private final Set<String> unresolvedShortCodes;
+        private final Set<String> missingItemsInCards;
+
+        private RailWorkflowBatchResult(List<String> trainIds,
+                                        List<RailWorkflowResult> results,
+                                        List<RailStopRecord> rawRows,
+                                        List<RailCarAggregate> aggregates,
+                                        List<RailCarCard> cards,
+                                        Map<String, RailFamilyFootprint> resolvedFootprints,
+                                        Set<String> unresolvedShortCodes,
+                                        Set<String> missingItemsInCards) {
+            this.trainIds = Collections.unmodifiableList(new ArrayList<>(trainIds));
+            this.results = Collections.unmodifiableList(new ArrayList<>(results));
+            this.rawRows = Collections.unmodifiableList(new ArrayList<>(rawRows));
+            this.aggregates = Collections.unmodifiableList(new ArrayList<>(aggregates));
+            this.cards = Collections.unmodifiableList(new ArrayList<>(cards));
+            this.resolvedFootprints = Collections.unmodifiableMap(new LinkedHashMap<>(resolvedFootprints));
+            this.unresolvedShortCodes = Collections.unmodifiableSet(new TreeSet<>(unresolvedShortCodes));
+            this.missingItemsInCards = Collections.unmodifiableSet(new TreeSet<>(missingItemsInCards));
+        }
+
+        public List<String> getTrainIds() {
+            return trainIds;
+        }
+
+        public List<RailWorkflowResult> getResults() {
+            return results;
         }
 
         public List<RailStopRecord> getRawRows() {

--- a/core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java
+++ b/core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java
@@ -132,6 +132,7 @@ public final class RailWorkflowService {
                 aggregate.getSequence(),
                 aggregate.getVehicleId(),
                 aggregate.getLoadNumberDisplay(),
+                routeHeader(aggregate),
                 sortedItems,
                 cardPlan.canPallets(),
                 cardPlan.domPallets(),
@@ -139,6 +140,20 @@ public final class RailWorkflowService {
                 cardPlan.topFamilies(),
                 cardPlan.missingItems()
         );
+    }
+
+    private String routeHeader(RailCarAggregate aggregate) {
+        List<String> parts = new ArrayList<>(3);
+        if (!aggregate.getTrainNumber().isBlank()) {
+            parts.add(aggregate.getTrainNumber());
+        }
+        if (!aggregate.getWarehouse().isBlank()) {
+            parts.add(aggregate.getWarehouse());
+        }
+        if (!aggregate.getLoadNumberDisplay().isBlank()) {
+            parts.add(aggregate.getLoadNumberDisplay());
+        }
+        return String.join(" ", parts);
     }
 
     private String normalizeTrainId(String trainId) {

--- a/core/src/main/java/com/tbg/wms/core/update/UpdateCatalogService.java
+++ b/core/src/main/java/com/tbg/wms/core/update/UpdateCatalogService.java
@@ -131,7 +131,6 @@ public final class UpdateCatalogService {
                 releaseNode.path("name").asText(""),
                 releaseNode.path("html_url").asText(""),
                 prerelease,
-                draft,
                 parseAssets(releaseNode.path("assets"))
         );
     }
@@ -173,7 +172,6 @@ public final class UpdateCatalogService {
             String releaseName,
             String releaseUrl,
             boolean prerelease,
-            boolean draft,
             List<ReleaseCheckService.ReleaseAsset> assets
     ) {
         public ReleaseEntry {

--- a/core/src/main/java/com/tbg/wms/core/update/VersionSupport.java
+++ b/core/src/main/java/com/tbg/wms/core/update/VersionSupport.java
@@ -219,18 +219,20 @@ public final class VersionSupport {
                     continue;
                 }
                 StringBuilder current = new StringBuilder();
-                Boolean currentNumeric = null;
+                boolean currentNumeric = false;
+                boolean hasCurrent = false;
                 for (int i = 0; i < group.length(); i++) {
                     char ch = group.charAt(i);
                     boolean numeric = Character.isDigit(ch);
-                    if (currentNumeric != null && currentNumeric != numeric) {
+                    if (hasCurrent && currentNumeric != numeric) {
                         tokens.add(QualifierToken.of(current.toString(), currentNumeric));
                         current.setLength(0);
                     }
                     current.append(ch);
                     currentNumeric = numeric;
+                    hasCurrent = true;
                 }
-                if (current.length() > 0 && currentNumeric != null) {
+                if (hasCurrent) {
                     tokens.add(QualifierToken.of(current.toString(), currentNumeric));
                 }
             }

--- a/core/src/test/java/com/tbg/wms/core/PrintRuntimeConfigSupportTest.java
+++ b/core/src/test/java/com/tbg/wms/core/PrintRuntimeConfigSupportTest.java
@@ -19,7 +19,7 @@ final class PrintRuntimeConfigSupportTest {
 
         assertEquals("config/printer-routing.yaml", support.printerRoutingFile());
         assertEquals("DISPATCH", support.defaultPrinterId());
-        assertEquals(0.125d, support.railLabelCenterGapInches());
+        assertEquals(0.1875d, support.railLabelCenterGapInches());
         assertEquals(0.02d, support.railLabelOffsetXInches());
         assertEquals(0.02d, support.railLabelOffsetYInches());
         assertNull(support.railDefaultPrinterIdOrNull());

--- a/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
@@ -61,6 +61,22 @@ final class RailCardRendererTest {
     }
 
     @Test
+    void renderPdfUsesRouteHeaderInsteadOfLoadOnly() throws Exception {
+        Path output = Files.createTempFile("rail-cards-route-header-test", ".pdf");
+        RailCarCard card = new RailCarCard("JC05262026", "301", "TPIX3204", "8000618166",
+                "0526 BR 8000618166",
+                List.of(new RailStopRecord.ItemQuantity("20548", 2200)),
+                0, 66, 0, List.of("DOM:100"), List.of());
+
+        new RailCardRenderer().renderPdf(List.of(card), output);
+
+        try (PDDocument doc = PDDocument.load(output.toFile())) {
+            String text = new PDFTextStripper().getText(doc);
+            assertTrue(text.contains("0526 BR 8000618166"));
+        }
+    }
+
+    @Test
     void renderAlignmentTemplateCreatesOneLetterPage() throws Exception {
         Path output = Files.createTempFile("rail-alignment-template-test", ".pdf");
         new RailCardRenderer().renderAlignmentTemplate(output);

--- a/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
@@ -1,10 +1,12 @@
 package com.tbg.wms.core.rail;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,5 +33,50 @@ final class RailCardRendererTest {
         try (PDDocument doc = PDDocument.load(output.toFile())) {
             assertEquals(1, doc.getNumberOfPages());
         }
+    }
+
+    @Test
+    void renderPdfPaginatesAfterTenCards() throws Exception {
+        Path output = Files.createTempFile("rail-cards-pagination-test", ".pdf");
+        new RailCardRenderer().renderPdf(cards(11), output);
+
+        try (PDDocument doc = PDDocument.load(output.toFile())) {
+            assertEquals(2, doc.getNumberOfPages());
+        }
+    }
+
+    @Test
+    void renderPdfUsesCompactMainDestinationCountText() throws Exception {
+        Path output = Files.createTempFile("rail-cards-main-count-test", ".pdf");
+        RailCarCard card = new RailCarCard("JC04152026", "302", "TPIX3127", "0415 FP 8000582489",
+                List.of(new RailStopRecord.ItemQuantity("20554", 7600)),
+                0, 76, 0, List.of("DOM:100"), List.of());
+
+        new RailCardRenderer().renderPdf(List.of(card), output);
+
+        try (PDDocument doc = PDDocument.load(output.toFile())) {
+            String text = new PDFTextStripper().getText(doc);
+            assertTrue(text.contains("DOM:76"));
+        }
+    }
+
+    @Test
+    void renderAlignmentTemplateCreatesOneLetterPage() throws Exception {
+        Path output = Files.createTempFile("rail-alignment-template-test", ".pdf");
+        new RailCardRenderer().renderAlignmentTemplate(output);
+
+        try (PDDocument doc = PDDocument.load(output.toFile())) {
+            assertEquals(1, doc.getNumberOfPages());
+        }
+    }
+
+    private static List<RailCarCard> cards(int count) {
+        List<RailCarCard> cards = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            cards.add(new RailCarCard("TRAIN", String.valueOf(i + 1), "CAR" + i, "L" + i,
+                    List.of(new RailStopRecord.ItemQuantity("01830", 120)),
+                    2, 1, 0, List.of("DOM:100"), List.of()));
+        }
+        return cards;
     }
 }

--- a/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class RailCardRendererTest {
@@ -73,6 +74,30 @@ final class RailCardRendererTest {
         try (PDDocument doc = PDDocument.load(output.toFile())) {
             String text = new PDFTextStripper().getText(doc);
             assertTrue(text.contains("0526 BR 8000618166"));
+        }
+    }
+
+    @Test
+    void renderPdfPrintsEveryItemLineWithoutContinuationText() throws Exception {
+        Path output = Files.createTempFile("rail-cards-all-items-test", ".pdf");
+        RailCarCard card = new RailCarCard("JC05262026", "301", "TPIX3204", "8000618166",
+                "0526 BR 8000618166",
+                List.of(
+                        new RailStopRecord.ItemQuantity("00906", 440),
+                        new RailStopRecord.ItemQuantity("20547", 700),
+                        new RailStopRecord.ItemQuantity("20548", 2200),
+                        new RailStopRecord.ItemQuantity("20551", 1000),
+                        new RailStopRecord.ItemQuantity("20567", 500),
+                        new RailStopRecord.ItemQuantity("2157", 825)
+                ),
+                0, 66, 0, List.of("DOM:100"), List.of());
+
+        new RailCardRenderer().renderPdf(List.of(card), output);
+
+        try (PDDocument doc = PDDocument.load(output.toFile())) {
+            String text = new PDFTextStripper().getText(doc);
+            assertTrue(text.contains("2157 825"));
+            assertFalse(text.contains("... 1 more"));
         }
     }
 

--- a/core/src/test/java/com/tbg/wms/core/rail/RailLabelSheetLayoutTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailLabelSheetLayoutTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.core.rail;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class RailLabelSheetLayoutTest {
+
+    @Test
+    void defaultLayout_shouldUseApprovedPhysicalMedia() {
+        RailLabelSheetLayout layout = RailLabelSheetLayout.defaultLayout();
+
+        assertEquals(612.0f, layout.pageWidthPoints(), 0.001f);
+        assertEquals(792.0f, layout.pageHeightPoints(), 0.001f);
+        assertEquals(288.0f, layout.labelWidthPoints(), 0.001f);
+        assertEquals(144.0f, layout.labelHeightPoints(), 0.001f);
+        assertEquals(10, layout.slotsPerPage());
+    }
+
+    @Test
+    void slotBounds_shouldMatchTwoByFiveSheet() {
+        RailLabelSheetLayout layout = RailLabelSheetLayout.defaultLayout();
+
+        RailLabelSheetLayout.LabelSlot first = layout.slot(0);
+        RailLabelSheetLayout.LabelSlot second = layout.slot(1);
+        RailLabelSheetLayout.LabelSlot rowTwo = layout.slot(2);
+
+        assertEquals(11.25f, first.left(), 0.001f);
+        assertEquals(756.0f, first.top(), 0.001f);
+        assertEquals(612.0f, first.bottom(), 0.001f);
+        assertEquals(312.75f, second.left(), 0.001f);
+        assertEquals(756.0f, second.top(), 0.001f);
+        assertEquals(612.0f, second.bottom(), 0.001f);
+        assertEquals(11.25f, rowTwo.left(), 0.001f);
+        assertEquals(612.0f, rowTwo.top(), 0.001f);
+        assertEquals(468.0f, rowTwo.bottom(), 0.001f);
+    }
+
+    @Test
+    void slot_shouldRejectOutOfRangeSlotIndex() {
+        RailLabelSheetLayout layout = RailLabelSheetLayout.defaultLayout();
+
+        assertThrows(IllegalArgumentException.class, () -> layout.slot(-1));
+        assertThrows(IllegalArgumentException.class, () -> layout.slot(10));
+    }
+}

--- a/core/src/test/java/com/tbg/wms/core/rail/RailTrainInputParserTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailTrainInputParserTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.core.rail;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class RailTrainInputParserTest {
+
+    private final RailTrainInputParser parser = new RailTrainInputParser();
+
+    @Test
+    void parse_shouldAcceptConfiguredDelimitersAndPreserveOrder() {
+        assertEquals(
+                List.of("JC04152026", "JC05012026", "JC06012026"),
+                parser.parse("jc04152026, JC05012026 / jc06012026")
+        );
+        assertEquals(
+                List.of("JC04152026", "JC05012026", "JC06012026"),
+                parser.parse("JC04152026: JC05012026; JC06012026")
+        );
+    }
+
+    @Test
+    void parse_shouldDeduplicateByFirstOccurrence() {
+        assertEquals(
+                List.of("JC04152026", "JC05012026"),
+                parser.parse("JC04152026; jc05012026 / jc04152026")
+        );
+    }
+
+    @Test
+    void parse_shouldRejectInputWithoutTrainIds() {
+        IllegalArgumentException nullEx = assertThrows(
+                IllegalArgumentException.class,
+                () -> parser.parse(null)
+        );
+        IllegalArgumentException blankEx = assertThrows(
+                IllegalArgumentException.class,
+                () -> parser.parse(" , / ; : ")
+        );
+
+        assertEquals("At least one train ID is required.", nullEx.getMessage());
+        assertEquals("At least one train ID is required.", blankEx.getMessage());
+    }
+}

--- a/core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java
@@ -96,6 +96,27 @@ final class RailWorkflowServiceTest {
         assertTrue(ex.getMessage().contains("MISSING"));
     }
 
+    @Test
+    void prepareBuildsRouteHeaderFromTrainNumberWarehouseAndLoadNumber() {
+        RailWorkflowService service = new RailWorkflowService(new RailDbRepository() {
+            @Override
+            public List<RailStopRecord> findRailStopsByTrainId(String trainId) {
+                return List.of(new RailStopRecord("05-29-26", "301", "0526", "TPIX3204", "BR", "8000618166",
+                        List.of(new RailStopRecord.ItemQuantity("20548", 2200))));
+            }
+
+            @Override
+            public Map<String, List<RailFootprintCandidate>> findRailFootprintsByShortCode(List<String> shortCodes) {
+                return Map.of("20548", List.of(new RailFootprintCandidate("20548", "ITEM1", "DOM", 56)));
+            }
+        });
+
+        RailCarCard card = service.prepare("JC05262026").getCards().get(0);
+
+        assertEquals("8000618166", card.getLoadNumbers());
+        assertEquals("0526 BR 8000618166", card.getRouteHeader());
+    }
+
     private static RailStopRecord row(String trainId, String sequence, String vehicle, String item, int cases) {
         return new RailStopRecord("03-04-26", sequence, trainId, vehicle, "BR", "L1",
                 List.of(new RailStopRecord.ItemQuantity(item, cases)));

--- a/core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java
+++ b/core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java
@@ -2,10 +2,13 @@ package com.tbg.wms.core.rail;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class RailWorkflowServiceTest {
 
@@ -36,5 +39,81 @@ final class RailWorkflowServiceTest {
         assertEquals(2, result.getCards().size());
         assertEquals(2, result.getCards().get(0).getDomPallets());
         assertEquals(1, result.getCards().get(1).getDomPallets());
+    }
+
+    @Test
+    void prepareAllKeepsInputOrderThenCardOrder() {
+        RailWorkflowService service = new RailWorkflowService(new RailDbRepository() {
+            @Override
+            public List<RailStopRecord> findRailStopsByTrainId(String trainId) {
+                if ("TRAINB".equals(trainId)) {
+                    return List.of(
+                            row("TRAINB", "200", "CAR-B1", "I1", 56),
+                            row("TRAINB", "201", "CAR-B2", "I1", 112)
+                    );
+                }
+                if ("TRAINA".equals(trainId)) {
+                    return List.of(row("TRAINA", "100", "CAR-A1", "I1", 56));
+                }
+                return List.of();
+            }
+
+            @Override
+            public Map<String, List<RailFootprintCandidate>> findRailFootprintsByShortCode(List<String> shortCodes) {
+                return Map.of("I1", List.of(new RailFootprintCandidate("I1", "ITEM1", "DOM", 56)));
+            }
+        });
+
+        RailWorkflowService.RailWorkflowBatchResult result = service.prepareAll(List.of("TRAINB", "TRAINA"));
+
+        assertEquals(List.of("TRAINB", "TRAINA"), result.getTrainIds());
+        assertEquals(List.of("TRAINB", "TRAINB", "TRAINA"), trainIds(result.getCards()));
+        assertEquals(List.of("200", "201", "100"), sequences(result.getCards()));
+    }
+
+    @Test
+    void prepareAllFailsWhenAnyTrainIsMissing() {
+        RailWorkflowService service = new RailWorkflowService(new RailDbRepository() {
+            @Override
+            public List<RailStopRecord> findRailStopsByTrainId(String trainId) {
+                if ("TRAIN1".equals(trainId)) {
+                    return List.of(row("TRAIN1", "100", "CAR-1", "I1", 56));
+                }
+                return List.of();
+            }
+
+            @Override
+            public Map<String, List<RailFootprintCandidate>> findRailFootprintsByShortCode(List<String> shortCodes) {
+                return Map.of("I1", List.of(new RailFootprintCandidate("I1", "ITEM1", "DOM", 56)));
+            }
+        });
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.prepareAll(List.of("TRAIN1", "MISSING"))
+        );
+
+        assertTrue(ex.getMessage().contains("MISSING"));
+    }
+
+    private static RailStopRecord row(String trainId, String sequence, String vehicle, String item, int cases) {
+        return new RailStopRecord("03-04-26", sequence, trainId, vehicle, "BR", "L1",
+                List.of(new RailStopRecord.ItemQuantity(item, cases)));
+    }
+
+    private static List<String> trainIds(List<RailCarCard> cards) {
+        List<String> trainIds = new ArrayList<>(cards.size());
+        for (RailCarCard card : cards) {
+            trainIds.add(card.getTrainId());
+        }
+        return trainIds;
+    }
+
+    private static List<String> sequences(List<RailCarCard> cards) {
+        List<String> sequences = new ArrayList<>(cards.size());
+        for (RailCarCard card : cards) {
+            sequences.add(card.getSequence());
+        }
+        return sequences;
     }
 }

--- a/core/src/test/java/com/tbg/wms/core/update/UpdateActionServiceTest.java
+++ b/core/src/test/java/com/tbg/wms/core/update/UpdateActionServiceTest.java
@@ -98,7 +98,6 @@ class UpdateActionServiceTest {
                 "v" + version,
                 "https://example.test/releases/v" + version,
                 prerelease,
-                false,
                 assets
         );
     }

--- a/core/src/test/java/com/tbg/wms/core/update/UpdatePolicyServiceTest.java
+++ b/core/src/test/java/com/tbg/wms/core/update/UpdatePolicyServiceTest.java
@@ -81,7 +81,6 @@ class UpdatePolicyServiceTest {
                 "v" + version,
                 "https://example.test/releases/v" + version,
                 prerelease,
-                false,
                 List.of(new ReleaseCheckService.ReleaseAsset(
                         "WMS.Pallet.Tag.System-" + version + ".exe",
                         "https://example.test/releases/v" + version + "/installer.exe"))

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.tbg.wms</groupId>
         <artifactId>wms-pallet-tag-system</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>db</artifactId>

--- a/docs/architecture-solid-audit.md
+++ b/docs/architecture-solid-audit.md
@@ -1,0 +1,95 @@
+# Architecture And SOLID Audit
+
+Last updated: 2026-06-01
+
+## Current Baseline
+
+The project is a Java 17 Maven multi-module desktop and CLI application:
+
+- `core` owns domain services, label planning, rail calculations, template rendering, printer routing, update policy, and runtime configuration.
+- `db` owns Oracle connection pooling and WMS query/hydration support.
+- `cli` owns Picocli command parsing and command-specific output formatting.
+- `gui` owns Swing workflows, operator dialogs, preview state, update UI, analyzers, and GUI-only workflow orchestration.
+- `scripts` owns packaging, installer, smoke-test, and VM validation automation.
+- `vba` preserves Excel macro helpers used by legacy rail workflows.
+
+The latest local verification baseline for this audit used:
+
+```powershell
+.\mvnw.cmd -q -pl core,db,gui,cli -am test
+java -jar cli\target\cli-1.7.6.jar --help
+```
+
+The Maven test command exited `0`. The CLI help smoke printed the expected command list.
+
+## Open Work
+
+Open GitHub issues at audit time:
+
+- `#42` Rail label generation improvements: larger/readable labels, documented physical label geometry, multi-train input, combined PDF generation, explicit printable-row selection, and SRP/SOLID preservation.
+- `#43` Contextual GUI help: shared help buttons and per-view operator guidance without duplicating dialog rendering.
+
+Recent merged repository context:
+
+- PR `#41` added the Daily Operations analyzer dashboard and package hardening.
+- Local `main` was ahead of `origin/main` with rail and Oracle ODBC planning commits.
+
+## SOLID Boundary Rules
+
+Use these rules when adding features or refactoring:
+
+- Single Responsibility: parsing, data access, orchestration, rendering, UI state, persistence, and external process execution should each have one owner.
+- Open/Closed: add new analyzers, rail render variants, and command formatting through focused implementations rather than condition-heavy changes in existing coordinators.
+- Liskov Substitution: analyzer providers and section loaders should keep shared contracts predictable, including failure snapshots and load timing behavior.
+- Interface Segregation: do not force UI classes to depend on DB, printer, update, or renderer details they do not use directly.
+- Dependency Inversion: UI and command layers should depend on services or small support classes, with direct environment, file-system, network, and database access pushed behind injectable boundaries.
+
+## Current Hotspots
+
+These files are not automatically wrong, but they carry enough responsibility that new work should reduce pressure rather than add more:
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/LabelGuiFrame.java` - broad Swing coordinator for startup, menus, dialogs, workflow wiring, and status behavior.
+- `gui/src/main/java/com/tbg/wms/cli/gui/BarcodeDialogFactory.java` - sizable dialog construction and behavior wiring.
+- `gui/src/main/java/com/tbg/wms/cli/gui/AdvancedPrintWorkflowService.java` - complex workflow orchestration that should stay clear of UI rendering and persistence details.
+- `scripts/run-smoke-tests.ps1` - valuable release harness, but broad enough that future changes should split manifest parsing, command execution, and reporting carefully.
+- `vba/m_Count_Product.bas` - legacy macro logic; preserve workbook behavior and add comments/tests or fixture evidence before further extraction.
+
+## Managed Branches
+
+Use `.worktrees/` for isolated branches. Current branch purposes:
+
+- `docs/repo-documentation-solid-audit`
+  - Documentation refresh, changelog notes, release checklist architecture gate, and this audit.
+- `refactor/srp-label-gui-frame`
+  - Extract low-risk responsibilities from `LabelGuiFrame` behind existing tested support classes.
+  - Candidate first steps: menu action registration, status footer updates, and dialog launch adapters.
+- `refactor/srp-analyzer-loading`
+  - Normalize analyzer loading state and asynchronous section loading after current dirty analyzer work is reviewed.
+  - Candidate first steps: keep data-provider concurrency in a coordinator and keep dashboard views passive.
+- `perf/code-optimization-baseline`
+  - Low-risk cleanup branch for repeated formatting, collection, parsing, and caching improvements.
+  - No behavior change should land without tests that already pass before the refactor.
+
+## Refactor Criteria
+
+Start a refactor only when at least one of these is true:
+
+- a file has more than one clear reason to change during the current feature
+- a collaborator cannot understand public behavior without reading UI or infrastructure internals
+- tests require excessive setup because dependencies are too broad
+- a release bug touched the same coordinator more than once
+- performance cleanup can be proven by simpler code or a measurable smoke/test result
+
+Avoid refactors that only rename, reshuffle, or split code without improving testability, responsibility boundaries, or reviewability.
+
+## Verification Expectations
+
+Before merging any refactor branch:
+
+```powershell
+.\mvnw.cmd -q -pl core,db,gui,cli -am test
+.\mvnw.cmd -q -pl cli -am package -DskipTests
+java -jar cli\target\cli-1.7.6.jar --help
+```
+
+For release branches, also run the smoke commands in `docs/release-checklist.md`.

--- a/docs/architecture-solid-audit.md
+++ b/docs/architecture-solid-audit.md
@@ -17,7 +17,7 @@ The latest local verification baseline for this audit used:
 
 ```powershell
 .\mvnw.cmd -q -pl core,db,gui,cli -am test
-java -jar cli\target\cli-1.7.6.jar --help
+java -jar cli\target\cli-1.8.0-SNAPSHOT.jar --help
 ```
 
 The Maven test command exited `0`. The CLI help smoke printed the expected command list.
@@ -89,7 +89,7 @@ Before merging any refactor branch:
 ```powershell
 .\mvnw.cmd -q -pl core,db,gui,cli -am test
 .\mvnw.cmd -q -pl cli -am package -DskipTests
-java -jar cli\target\cli-1.7.6.jar --help
+java -jar cli\target\cli-1.8.0-SNAPSHOT.jar --help
 ```
 
 For release branches, also run the smoke commands in `docs/release-checklist.md`.

--- a/docs/next-agent-notes.md
+++ b/docs/next-agent-notes.md
@@ -1,5 +1,21 @@
 # Next Agent Notes
 
+## 2026-06-01 Repo Documentation And SRP Branch Setup
+
+- Baseline context:
+  - local `main` was ahead of `origin/main` by four documentation/planning commits
+  - the primary checkout had unrelated dirty analyzer/VBA/log/generated-label changes, so this documentation pass was isolated in `.worktrees/repo-documentation-solid-audit`
+  - open issues were `#42` rail label generation improvements and `#43` contextual GUI help
+- Verification before documentation edits:
+  - `.\mvnw.cmd -q -pl core,db,gui,cli -am test` passed in the documentation worktree
+  - earlier CLI smoke in the primary checkout confirmed `java -jar cli\target\cli-1.7.6.jar --help` prints the expected command list
+- Managed branch map:
+  - `docs/repo-documentation-solid-audit` for README/CHANGELOG/release-doc/SRP-audit updates
+  - `refactor/srp-label-gui-frame` for narrowing `LabelGuiFrame` and adjacent Swing coordinator responsibilities
+  - `refactor/srp-analyzer-loading` for analyzer async loading and dashboard loading-state boundaries
+  - `perf/code-optimization-baseline` for low-risk performance cleanup after a fresh verification baseline
+- Keep the existing dirty analyzer and VBA changes intact unless the user explicitly asks to integrate or discard them.
+
 ## 2026-03-24 Validation Notes
 
 - Clean-VM validation was rerun against the `TropTest` VirtualBox guest with no Java on `PATH`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -67,6 +67,13 @@ Latest validated reports on `1.7.6`:
   - installed app `config`
   - installed app `db-test`
 
+## Architecture And Documentation Checks
+
+- Confirm README and CHANGELOG describe release-visible workflow, packaging, or operator changes.
+- Confirm any durable architecture decision is documented in `docs/adr/` or the relevant focused doc.
+- Confirm SRP-sensitive changes keep parsing, data access, orchestration, rendering, and UI state responsibilities separated.
+- Confirm large coordinator changes identify the follow-up refactor branch or plan when full extraction is outside the release scope.
+
 ## Release Gate
 
 Do not create or push a release tag unless:
@@ -77,3 +84,4 @@ Do not create or push a release tag unless:
 - no Tier 1 scenario remains uncovered in [release-smoke-coverage-matrix.md](release-smoke-coverage-matrix.md)
 - remaining GUI-only/manual surface is documented in [gui-backend-coverage-inventory.md](gui-backend-coverage-inventory.md)
 - generated reports are available for review
+- architecture and documentation checks above are complete

--- a/docs/superpowers/plans/2026-05-18-oracle-odbc-setup-installer.md
+++ b/docs/superpowers/plans/2026-05-18-oracle-odbc-setup-installer.md
@@ -1,0 +1,814 @@
+# Oracle ODBC Setup Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a local-only Intune-ready Windows executable that installs Oracle 19c 64-bit ODBC connectivity and creates all Warehouse Analyzer System DSNs.
+
+**Architecture:** Keep the installer engine in readable PowerShell scripts under `scripts/odbc-setup/`, with pure functions isolated in `ODBCSetup.Core.ps1` so most behavior can be tested without Oracle installed. `build-exe.ps1` stages the scripts plus a local Oracle ZIP and generates a single self-extracting executable under `dist/odbc-setup/`; the Oracle ZIP and generated EXE remain local artifacts only.
+
+**Tech Stack:** Windows PowerShell 5.1 compatible scripts, `cmd.exe` launcher, .NET Framework/C# compiler for the self-extracting wrapper when available, Windows ODBC cmdlets and 64-bit registry fallback, simple repo-local PowerShell tests.
+
+---
+
+## File Structure
+
+- Create: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+  - Pure functions and small side-effect helpers shared by install, detect, uninstall, and tests.
+  - Owns site inventory, `tnsnames.ora` rendering, response-file patching, Oracle driver discovery, DSN registry payload generation, verification result formatting, and log redaction helpers.
+- Create: `scripts/odbc-setup/install.cmd`
+  - Minimal entry point that launches 64-bit PowerShell with execution policy bypass and passes through arguments.
+- Create: `scripts/odbc-setup/install-odbc.ps1`
+  - Orchestrates install: elevation/platform checks, payload extraction, Oracle silent install, network config write, DSN creation, optional credential smoke tests, verification, logging, and exit codes.
+- Create: `scripts/odbc-setup/detect.ps1`
+  - Intune detection script. It imports core functions, runs structural/offline verification only, prints concise results, and exits `0` only when installed state is complete.
+- Create: `scripts/odbc-setup/uninstall.ps1`
+  - Removes package-owned DSNs and metadata by default. Optional `-RemoveOracleClient` switch may be stubbed or implemented only if safe.
+- Create: `scripts/odbc-setup/build-exe.ps1`
+  - Builds local bundle/executable from committed scripts plus a local Oracle ZIP path.
+- Create: `scripts/odbc-setup/README.md`
+  - IT-facing build/deploy notes, including the local-only Oracle ZIP rule.
+- Create: `scripts/odbc-setup/payload/oracle-client-install.rsp.template`
+  - Response file template with token placeholders.
+- Create: `scripts/tests/odbc-setup.tests.ps1`
+  - Pure-function and packaging-staging tests that do not require Oracle.
+- Modify: `.gitignore`
+  - Ensure local ODBC artifacts and payload ZIP are ignored even if someone stages them accidentally.
+- Modify: `docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md`
+  - Already updated for optional credential smoke-test policy; commit this with the plan.
+
+---
+
+### Task 1: Ignore Local Oracle Payload And Generated ODBC Artifacts
+
+**Files:**
+- Modify: `.gitignore`
+- Test: `git status --short -- scripts/odbc-setup dist/odbc-setup`
+
+- [ ] **Step 1: Add ignore patterns**
+
+Add these patterns near existing build/output ignores:
+
+```gitignore
+# Local-only Oracle ODBC setup payloads and generated packages
+dist/odbc-setup/
+scripts/odbc-setup/payload/*.zip
+scripts/odbc-setup/payload/*.7z
+scripts/odbc-setup/payload/*.exe
+```
+
+- [ ] **Step 2: Verify ignore behavior**
+
+Create a temporary local file manually or with PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Path scripts\odbc-setup\payload -Force
+Set-Content -LiteralPath scripts\odbc-setup\payload\O19-64bit.zip -Value "fake" -Encoding ASCII
+git status --short -- scripts/odbc-setup/payload/O19-64bit.zip
+Remove-Item -LiteralPath scripts\odbc-setup\payload\O19-64bit.zip -Force
+```
+
+Expected: `git status` prints nothing for the fake ZIP.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add .gitignore
+git commit -m "chore(odbc): ignore local installer artifacts"
+```
+
+---
+
+### Task 2: Add Core Site Inventory And TNS Rendering Tests
+
+**Files:**
+- Create: `scripts/tests/odbc-setup.tests.ps1`
+- Create: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+
+- [ ] **Step 1: Write failing tests for site inventory and TNS output**
+
+Create `scripts/tests/odbc-setup.tests.ps1` with local assertion helpers matching the existing script-test style:
+
+```powershell
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param([string]$Expected, [string]$Actual, [string]$Message)
+    if ($Expected -ne $Actual) { throw "$Message`nExpected: $Expected`nActual:   $Actual" }
+}
+
+$scriptRoot = Split-Path -Parent $PSCommandPath
+$sourceRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$coreScript = Join-Path $sourceRoot "scripts\odbc-setup\ODBCSetup.Core.ps1"
+. $coreScript
+
+$sites = Get-OdbcSetupSites
+Assert-Equal "7" ([string]$sites.Count) "Should define seven Warehouse Analyzer sites"
+Assert-True ($sites.Code -contains "TBG3002") "Should include Jersey City TBG3002"
+
+$tns = New-TnsNamesContent -Sites $sites
+foreach ($site in $sites) {
+    Assert-True ($tns.Contains($site.Code + " =")) "tnsnames should include alias $($site.Code)"
+    Assert-True ($tns.Contains("(HOST = $($site.Host))")) "tnsnames should include host $($site.Host)"
+}
+Assert-True ($tns.Contains("(PORT = 1521)")) "tnsnames should include port 1521"
+Assert-True ($tns.Contains("(SERVICE_NAME = WMSP)")) "tnsnames should include service WMSP"
+
+Write-Host "PASS: odbc setup core generates site inventory and tnsnames.ora"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL because `ODBCSetup.Core.ps1` or functions do not exist.
+
+- [ ] **Step 3: Implement minimal core functions**
+
+Create `scripts/odbc-setup/ODBCSetup.Core.ps1`:
+
+```powershell
+$script:OdbcSetupSites = @(
+    [pscustomobject]@{ Code = 'TBG1000'; Name = 'Bradenton'; Host = '10.18.228.52' },
+    [pscustomobject]@{ Code = 'TBG1010'; Name = 'City of Industry'; Host = '10.19.96.103' },
+    [pscustomobject]@{ Code = 'TBG1011'; Name = 'Fort Pierce'; Host = '10.18.228.72' },
+    [pscustomobject]@{ Code = 'TBG1279'; Name = 'Kevita'; Host = '10.19.96.104' },
+    [pscustomobject]@{ Code = 'TBG3002'; Name = 'Jersey'; Host = '10.19.68.61' },
+    [pscustomobject]@{ Code = 'TBG3230'; Name = 'Midwest'; Host = '10.18.228.66' },
+    [pscustomobject]@{ Code = 'TBG3322'; Name = 'Walnut'; Host = '10.19.68.53' }
+)
+
+function Get-OdbcSetupSites {
+    return @($script:OdbcSetupSites)
+}
+
+function New-TnsNamesContent {
+    param([object[]]$Sites = (Get-OdbcSetupSites))
+
+    $blocks = foreach ($site in $Sites) {
+@"
+$($site.Code) =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = $($site.Host))(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVICE_NAME = WMSP)
+    )
+  )
+"@
+    }
+    return (($blocks -join [Environment]::NewLine + [Environment]::NewLine) + [Environment]::NewLine)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add site inventory and tns rendering"
+```
+
+---
+
+### Task 3: Add Response File Patching And Secret Redaction
+
+**Files:**
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+- Modify: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+- Create: `scripts/odbc-setup/payload/oracle-client-install.rsp.template`
+
+- [ ] **Step 1: Write failing tests**
+
+Append tests:
+
+```powershell
+$template = @"
+ORACLE_BASE=__ORACLE_BASE__
+ORACLE_HOME=__ORACLE_HOME__
+oracle.install.IsBuiltInAccount=__BUILT_IN_ACCOUNT__
+oracle.install.client.installType=__INSTALL_TYPE__
+"@
+$response = New-OracleClientResponseContent -TemplateContent $template `
+    -OracleBase "C:\App\Client\Oracle" `
+    -OracleHome "C:\App\Client\Oracle\Product\19.0.0\Client_1"
+Assert-True ($response.Contains("ORACLE_BASE=C:\App\Client\Oracle")) "Response should set Oracle base"
+Assert-True ($response.Contains("ORACLE_HOME=C:\App\Client\Oracle\Product\19.0.0\Client_1")) "Response should set Oracle home"
+Assert-True ($response.Contains("oracle.install.IsBuiltInAccount=true")) "Response should use built-in account"
+Assert-True ($response.Contains("oracle.install.client.installType=Administrator")) "Response should use Administrator install"
+
+$redacted = Protect-OdbcSetupLogText "UID=RPTADM;PWD=Report_Password12!@#;Password=abc"
+Assert-True (-not $redacted.Contains("Report_Password12")) "Redaction should remove PWD value"
+Assert-True (-not $redacted.Contains("Password=abc")) "Redaction should remove Password value"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL for missing functions.
+
+- [ ] **Step 3: Implement response and redaction functions**
+
+Add to core:
+
+```powershell
+function New-OracleClientResponseContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$TemplateContent,
+        [Parameter(Mandatory = $true)][string]$OracleBase,
+        [Parameter(Mandatory = $true)][string]$OracleHome
+    )
+
+    return $TemplateContent.
+        Replace('__ORACLE_BASE__', $OracleBase).
+        Replace('__ORACLE_HOME__', $OracleHome).
+        Replace('__BUILT_IN_ACCOUNT__', 'true').
+        Replace('__INSTALL_TYPE__', 'Administrator')
+}
+
+function Protect-OdbcSetupLogText {
+    param([string]$Text)
+    if ($null -eq $Text) { return $null }
+    $safe = $Text -replace '(?i)(PWD|Password)\s*=\s*[^;\s]+', '$1=<redacted>'
+    return $safe
+}
+```
+
+Create response template:
+
+```text
+ORACLE_BASE=__ORACLE_BASE__
+ORACLE_HOME=__ORACLE_HOME__
+oracle.install.IsBuiltInAccount=__BUILT_IN_ACCOUNT__
+oracle.install.client.installType=__INSTALL_TYPE__
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/odbc-setup/payload/oracle-client-install.rsp.template scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add response rendering and log redaction"
+```
+
+---
+
+### Task 4: Add DSN Payload And Verification Model
+
+**Files:**
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+- Modify: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+
+- [ ] **Step 1: Write failing tests for DSN values and credential omission**
+
+Append tests:
+
+```powershell
+$dsnValues = New-OdbcDsnPropertyValues -SiteCode "TBG3002"
+Assert-True ($dsnValues -contains "ServerName=TBG3002") "DSN values should include ServerName"
+Assert-True ($dsnValues -contains "DBQ=TBG3002") "DSN values should include DBQ"
+Assert-True (-not (($dsnValues -join ';') -match '(?i)UID|PWD|Password')) "DSN values should omit credentials"
+
+$registry = New-OdbcDsnRegistryValueMap -SiteCode "TBG3002" -DriverName "Oracle in OraClient19Home1"
+Assert-Equal "Oracle in OraClient19Home1" $registry["Driver"] "Registry values should include driver"
+Assert-Equal "TBG3002" $registry["ServerName"] "Registry values should include ServerName"
+Assert-True (-not ($registry.ContainsKey("UID"))) "Registry values should omit UID"
+Assert-True (-not ($registry.ContainsKey("PWD"))) "Registry values should omit PWD"
+
+$result = New-OdbcSetupCheckResult -Check "DSN TBG3002" -Passed $true -Details "ok"
+Assert-Equal "DSN TBG3002" $result.Check "Verification result should preserve check name"
+Assert-Equal "True" ([string]$result.Passed) "Verification result should preserve pass state"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL for missing DSN/verification functions.
+
+- [ ] **Step 3: Implement DSN payload helpers**
+
+Add to core:
+
+```powershell
+function New-OdbcDsnPropertyValues {
+    param([Parameter(Mandatory = $true)][string]$SiteCode)
+    return @(
+        "ServerName=$SiteCode",
+        "DBQ=$SiteCode"
+    )
+}
+
+function New-OdbcDsnRegistryValueMap {
+    param(
+        [Parameter(Mandatory = $true)][string]$SiteCode,
+        [Parameter(Mandatory = $true)][string]$DriverName
+    )
+
+    return [ordered]@{
+        Driver = $DriverName
+        ServerName = $SiteCode
+        DBQ = $SiteCode
+    }
+}
+
+function New-OdbcSetupCheckResult {
+    param([string]$Check, [bool]$Passed, [string]$Details)
+    [pscustomobject]@{
+        Check = $Check
+        Passed = $Passed
+        Details = $Details
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add dsn payload helpers"
+```
+
+---
+
+### Task 5: Implement Offline Detection
+
+**Files:**
+- Modify: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+- Create: `scripts/odbc-setup/detect.ps1`
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+
+- [ ] **Step 1: Write failing tests for detection result aggregation**
+
+Append tests that use temporary registry/config paths through test seams rather than real HKLM writes:
+
+```powershell
+$missing = Test-OdbcSetupState -OracleHome "Z:\missing-oracle-home" -DriverName $null -TnsContent "" -DsnMap @{}
+Assert-True (($missing | Where-Object { -not $_.Passed }).Count -gt 0) "Missing state should produce failures"
+
+$sites = Get-OdbcSetupSites
+$presentDsnMap = @{}
+foreach ($site in $sites) { $presentDsnMap[$site.Code] = @{ ServerName = $site.Code; DBQ = $site.Code } }
+$present = Test-OdbcSetupState -OracleHome $env:TEMP -DriverName "Oracle in OraClient19Home1" -TnsContent (New-TnsNamesContent -Sites $sites) -DsnMap $presentDsnMap
+Assert-Equal "0" ([string](($present | Where-Object { -not $_.Passed }).Count)) "Complete test state should pass"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL for missing `Test-OdbcSetupState`.
+
+- [ ] **Step 3: Implement core state verification**
+
+Add `Test-OdbcSetupState` to core. It should accept injectable values for tests, and production wrappers can supply real filesystem/registry data.
+
+- [ ] **Step 4: Implement `detect.ps1`**
+
+Create script that:
+
+```powershell
+[CmdletBinding()]
+param(
+    [string]$OracleHome = "C:\App\Client\Oracle\Product\19.0.0\Client_1"
+)
+
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $PSCommandPath
+. (Join-Path $scriptRoot "ODBCSetup.Core.ps1")
+
+$driver = Get-InstalledOracleOdbcDriverName
+$tnsPath = Join-Path $OracleHome "Network\Admin\tnsnames.ora"
+$tnsContent = if (Test-Path -LiteralPath $tnsPath) { Get-Content -LiteralPath $tnsPath -Raw } else { "" }
+$dsnMap = Get-SystemOdbcDsnMap
+$results = Test-OdbcSetupState -OracleHome $OracleHome -DriverName $driver -TnsContent $tnsContent -DsnMap $dsnMap
+
+$results | ForEach-Object {
+    Write-Host ("[{0}] {1}: {2}" -f $(if ($_.Passed) { "PASS" } else { "FAIL" }), $_.Check, $_.Details)
+}
+
+if (($results | Where-Object { -not $_.Passed }).Count -gt 0) { exit 1 }
+exit 0
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/odbc-setup/detect.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add offline detection checks"
+```
+
+---
+
+### Task 6: Implement Install Orchestration
+
+**Files:**
+- Create: `scripts/odbc-setup/install.cmd`
+- Create: `scripts/odbc-setup/install-odbc.ps1`
+- Modify: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+
+- [ ] **Step 1: Add tests for credential smoke-test log redaction**
+
+Append tests:
+
+```powershell
+$smokeLog = Format-CredentialSmokeTestResult -SiteCode "TBG3002" -Username "RPTADM" -Passed $true -Message "ok"
+Assert-True ($smokeLog.Contains("TBG3002")) "Smoke log should include site"
+Assert-True ($smokeLog.Contains("RPTADM")) "Smoke log should include username"
+Assert-True (-not $smokeLog.Contains("Report_Password")) "Smoke log should not include password"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL for missing formatter.
+
+- [ ] **Step 3: Implement install helpers**
+
+Add side-effect helpers to core:
+
+- `Assert-OdbcSetupIs64BitPowerShell`
+- `Test-OdbcSetupIsElevated`
+- `Get-InstalledOracleOdbcDriverName`
+- `Get-SystemOdbcDsnMap`
+- `Set-SystemOdbcDsn`
+- `Write-TnsNamesFile`
+- `Invoke-OdbcCredentialSmokeTest`
+- `Format-CredentialSmokeTestResult`
+
+Keep credential smoke-test optional and in-memory:
+
+```powershell
+function Format-CredentialSmokeTestResult {
+    param([string]$SiteCode, [string]$Username, [bool]$Passed, [string]$Message)
+    $status = if ($Passed) { "passed" } else { "failed" }
+    return ("{0} credential test {1} as {2}: {3}" -f $SiteCode, $status, $Username, (Protect-OdbcSetupLogText $Message))
+}
+```
+
+- [ ] **Step 4: Create `install.cmd`**
+
+Use `%SystemRoot%\SysNative\WindowsPowerShell\v1.0\powershell.exe` when available so 32-bit launch contexts still reach 64-bit PowerShell:
+
+```bat
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+set PS=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe
+if exist "%SystemRoot%\SysNative\WindowsPowerShell\v1.0\powershell.exe" set PS=%SystemRoot%\SysNative\WindowsPowerShell\v1.0\powershell.exe
+"%PS%" -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%install-odbc.ps1" %*
+exit /b %ERRORLEVEL%
+```
+
+- [ ] **Step 5: Create `install-odbc.ps1`**
+
+Parameters:
+
+```powershell
+param(
+    [string]$OracleZipPath,
+    [string]$OracleBase = "C:\App\Client\Oracle",
+    [string]$OracleHome = "C:\App\Client\Oracle\Product\19.0.0\Client_1",
+    [string]$ProgramDataRoot = "C:\ProgramData\Tropicana\ODBCSetup",
+    [switch]$RunCredentialSmokeTest,
+    [string]$SmokeTestUsername,
+    [string]$SmokeTestPassword
+)
+```
+
+Behavior:
+
+- Resolve bundled `payload\O19-64bit.zip` if `-OracleZipPath` is not passed.
+- Create logs under `$ProgramDataRoot\Logs`.
+- Fail early if not 64-bit PowerShell or not elevated.
+- Expand Oracle ZIP to `$env:TEMP\Tropicana-ODBCSetup-*`.
+- Render response file.
+- Run Oracle `setup.exe` silently and capture exit code.
+- Write `tnsnames.ora`.
+- Create or repair all DSNs.
+- If `-RunCredentialSmokeTest`, require username/password and test each site in memory.
+- Run structural verification and exit nonzero if failures remain.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add scripts/odbc-setup/install.cmd scripts/odbc-setup/install-odbc.ps1 scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add installer orchestration"
+```
+
+---
+
+### Task 7: Implement Uninstall
+
+**Files:**
+- Create: `scripts/odbc-setup/uninstall.ps1`
+- Modify: `scripts/odbc-setup/ODBCSetup.Core.ps1`
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+
+- [ ] **Step 1: Write tests for uninstall target list**
+
+Append tests:
+
+```powershell
+$removeList = Get-OdbcSetupOwnedDsnNames
+Assert-Equal "7" ([string]$removeList.Count) "Uninstall should target seven owned DSNs"
+Assert-True ($removeList -contains "TBG3002") "Uninstall should target TBG3002"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL for missing function.
+
+- [ ] **Step 3: Implement uninstall helpers and script**
+
+`uninstall.ps1` should:
+
+- Import core.
+- Require elevation.
+- Remove each owned System DSN with ODBC cmdlets when available, then registry fallback.
+- Remove package-owned install state files, but preserve logs by default unless `-RemoveLogs` is passed.
+- Not remove Oracle Client unless `-RemoveOracleClient` is explicitly passed. If client removal is not implemented in this first pass, fail clearly when the switch is passed rather than silently doing nothing.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add scripts/odbc-setup/uninstall.ps1 scripts/odbc-setup/ODBCSetup.Core.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add dsn uninstall script"
+```
+
+---
+
+### Task 8: Implement Local EXE Builder
+
+**Files:**
+- Create: `scripts/odbc-setup/build-exe.ps1`
+- Modify: `scripts/tests/odbc-setup.tests.ps1`
+
+- [ ] **Step 1: Write tests for staging without real Oracle media**
+
+Append a test that creates a fake Oracle ZIP and verifies staging output:
+
+```powershell
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("odbc-build-test-" + [guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    $fakeZip = Join-Path $tempRoot "O19-64bit.zip"
+    Set-Content -LiteralPath $fakeZip -Value "fake zip" -Encoding ASCII
+    $out = Join-Path $tempRoot "out"
+    & (Join-Path $sourceRoot "scripts\odbc-setup\build-exe.ps1") -OracleZipPath $fakeZip -OutputDir $out -StageOnly
+    Assert-True (Test-Path -LiteralPath (Join-Path $out "stage\payload\O19-64bit.zip")) "Builder should stage Oracle ZIP"
+    Assert-True (Test-Path -LiteralPath (Join-Path $out "stage\install.cmd")) "Builder should stage install.cmd"
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: FAIL because builder does not exist.
+
+- [ ] **Step 3: Implement `build-exe.ps1` stage mode**
+
+Parameters:
+
+```powershell
+param(
+    [Parameter(Mandatory = $true)][string]$OracleZipPath,
+    [string]$OutputDir,
+    [switch]$StageOnly
+)
+```
+
+Behavior:
+
+- Resolve source root from script path.
+- Refuse missing Oracle ZIP.
+- Create `$OutputDir\stage`.
+- Copy committed setup files.
+- Copy Oracle ZIP as `payload\O19-64bit.zip`.
+- In `-StageOnly`, stop before compiling.
+
+- [ ] **Step 4: Add EXE generation**
+
+Implement self-extracting wrapper generation:
+
+- Compress stage folder into an embedded base64 ZIP or temporary resource.
+- Generate a small C# launcher source under temp.
+- Compile with the newest available `%WINDIR%\Microsoft.NET\Framework64\*\csc.exe`.
+- Launcher extracts payload ZIP to `%TEMP%\Tropicana-ODBCSetup-*`, runs `install.cmd`, waits, forwards exit code, and cleans extraction directory.
+- If no C# compiler is available, fail with an actionable message.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+```
+
+Expected: PASS. Stage-only test should pass without compiling an EXE.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/odbc-setup/build-exe.ps1 scripts/tests/odbc-setup.tests.ps1
+git commit -m "feat(odbc): add local executable builder"
+```
+
+---
+
+### Task 9: Add IT README And Final Verification
+
+**Files:**
+- Create: `scripts/odbc-setup/README.md`
+- Modify: `docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md` if implementation details changed
+
+- [ ] **Step 1: Write README**
+
+Include:
+
+- Purpose.
+- Build command:
+
+```powershell
+.\scripts\odbc-setup\build-exe.ps1 -OracleZipPath "C:\Users\zrashed\Downloads\O19-64bit (1).zip"
+```
+
+- Generated output path: `dist\odbc-setup\Tropicana-Oracle-ODBC-Setup.exe`.
+- Intune install command.
+- Intune detection command:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\detect.ps1
+```
+
+- Credential smoke-test policy:
+  - DSNs stay credential-free.
+  - Optional smoke test uses read-only credentials in memory.
+  - Password is not logged.
+- Uninstall behavior.
+
+- [ ] **Step 2: Run all script tests**
+
+Run:
+
+```powershell
+.\scripts\tests\odbc-setup.tests.ps1
+.\scripts\tests\build-tropicana-installer.tests.ps1
+.\scripts\tests\install-tropicana-config.tests.ps1
+.\scripts\tests\install-wms-installer.tests.ps1
+.\scripts\tests\run-smoke-tests.tests.ps1
+```
+
+Expected: all print `PASS` and exit `0`.
+
+- [ ] **Step 3: Build stage with local Oracle ZIP**
+
+Run when the Oracle ZIP is available locally:
+
+```powershell
+.\scripts\odbc-setup\build-exe.ps1 -OracleZipPath "C:\Users\zrashed\Downloads\O19-64bit (1).zip" -StageOnly
+```
+
+Expected: `dist\odbc-setup\stage\payload\O19-64bit.zip` exists and remains ignored by git.
+
+- [ ] **Step 4: Build EXE**
+
+Run:
+
+```powershell
+.\scripts\odbc-setup\build-exe.ps1 -OracleZipPath "C:\Users\zrashed\Downloads\O19-64bit (1).zip"
+```
+
+Expected: `dist\odbc-setup\Tropicana-Oracle-ODBC-Setup.exe` exists and remains ignored by git.
+
+- [ ] **Step 5: Check git status for forbidden artifacts**
+
+Run:
+
+```powershell
+git status --short -- scripts/odbc-setup dist/odbc-setup
+```
+
+Expected: committed scripts may appear before commit; no `*.zip` or generated `*.exe` appears.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add scripts/odbc-setup/README.md docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md
+git commit -m "docs(odbc): add setup build and deployment notes"
+```
+
+---
+
+## Manual Integration Validation
+
+Run these on a clean Windows VM or Intune test device, not on a developer machine with unknown Oracle state:
+
+- [ ] Install generated EXE through elevated PowerShell.
+- [ ] Confirm logs are written under `C:\ProgramData\Tropicana\ODBCSetup\Logs`.
+- [ ] Run `detect.ps1`; expect exit `0`.
+- [ ] Open 64-bit ODBC Administrator and confirm all seven System DSNs.
+- [ ] Run optional credential smoke test with read-only credentials; confirm logs show pass/fail per site without password.
+- [ ] Refresh one Excel Analyzer using its SOP connection string.
+- [ ] Rerun installer; confirm idempotent repair and no duplicate DSNs.
+- [ ] Run uninstall; confirm owned DSNs are removed and Oracle Client remains installed by default.

--- a/docs/superpowers/plans/2026-05-29-rail-label-generation-improvements.md
+++ b/docs/superpowers/plans/2026-05-29-rail-label-generation-improvements.md
@@ -235,11 +235,11 @@ void slotBounds_shouldMatchTwoByFiveSheet() {
     RailLabelSheetLayout.LabelSlot rowTwo = layout.slot(2);
 
     assertEquals(11.25f, first.left(), 0.001f);
-    assertEquals(648.0f, first.bottom(), 0.001f);
+    assertEquals(612.0f, first.bottom(), 0.001f);
     assertEquals(312.75f, second.left(), 0.001f);
-    assertEquals(648.0f, second.bottom(), 0.001f);
+    assertEquals(612.0f, second.bottom(), 0.001f);
     assertEquals(11.25f, rowTwo.left(), 0.001f);
-    assertEquals(504.0f, rowTwo.bottom(), 0.001f);
+    assertEquals(468.0f, rowTwo.bottom(), 0.001f);
 }
 ```
 

--- a/docs/superpowers/plans/2026-05-29-rail-label-generation-improvements.md
+++ b/docs/superpowers/plans/2026-05-29-rail-label-generation-improvements.md
@@ -1,0 +1,805 @@
+# Rail Label Generation Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the approved rail label improvements from issue `#42`: larger readable labels, documented physical-media layout, multi-train input, one combined PDF, and explicit row print selection.
+
+**Architecture:** Keep parsing, physical layout, rendering, workflow orchestration, printable-row filtering, and Swing UI state in separate focused classes. The existing single-train workflow remains the primitive; new multi-train behavior composes it and preserves deterministic order. The GUI preview owns operator row inclusion state explicitly through table model data, while rendering receives only the selected cards.
+
+**Tech Stack:** Java 17, Maven multi-module project, JUnit 5, Swing, PDFBox 2.0.31, Picocli, GitHub issue `#42`.
+
+---
+
+## Process Rules
+
+- Work from issue `#42`.
+- Use conventional commits with logical scope, for example `feat(rail): parse multiple train codes`.
+- Commit after each self-contained task.
+- Keep versioning semantic-version aware. This is user-facing feature work and should be documented as a candidate minor release unless the project release process decides otherwise.
+- Do not create the final PR until all tests pass and the user approves the shippable result.
+- Avoid unrelated refactors and ignore unrelated dirty worktree files.
+
+## File Structure
+
+Create:
+
+- `core/src/main/java/com/tbg/wms/core/rail/RailTrainInputParser.java`  
+  Parses operator train-code text into normalized ordered train IDs only.
+
+- `core/src/test/java/com/tbg/wms/core/rail/RailTrainInputParserTest.java`  
+  Covers delimiter, normalization, dedupe, and empty-input behavior.
+
+- `core/src/main/java/com/tbg/wms/core/rail/RailLabelSheetLayout.java`  
+  Owns physical sheet dimensions, inch-to-point conversion, 2x5 slot bounds, and Javadoc with all approved measurements/calculations.
+
+- `core/src/test/java/com/tbg/wms/core/rail/RailLabelSheetLayoutTest.java`  
+  Verifies sheet math and slot positions in points.
+
+- `core/src/main/java/com/tbg/wms/core/rail/RailLabelTypography.java`  
+  Optional focused constants holder for font sizes/styles if it keeps `RailCardRenderer` small.
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModel.java`  
+  Owns printable checkbox state and row-to-card mapping for the preview table.
+
+- `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModelTest.java`  
+  Covers default checked state, select all, clear all, invert, and selected-card extraction.
+
+Modify:
+
+- `core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java`  
+  Add multi-train composition while keeping existing `prepare(String)` behavior.
+
+- `core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java`  
+  Use `RailLabelSheetLayout` and larger typography; render only provided cards.
+
+- `core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java`  
+  Add multi-train order and strict failure tests.
+
+- `core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java`  
+  Add pagination and layout smoke coverage.
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupport.java`  
+  Parse multi-train preview input and validate selected-card generation.
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogActionSupport.java`  
+  Report selected/total counts in preview and generation outcomes as needed.
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java`  
+  Prepare multiple trains and generate PDFs from selected cards.
+
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java`  
+  Add checkbox table model, multi-select controls, and selected-card generation routing.
+
+- `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupportTest.java`  
+  Add parse and zero-selected validation coverage.
+
+- `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogActionSupportTest.java`  
+  Update preview/generation outcome expectations.
+
+- `cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCommand.java`  
+  Accept multi-train input and generate one combined PDF.
+
+- `cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupport.java`  
+  Validate/format multi-train preview text.
+
+- `cli/src/test/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupportTest.java`  
+  Add multi-train validation/preview coverage.
+
+- `CHANGELOG.md`  
+  Add an unreleased conventional entry if the project already uses such a section. If not, defer release-note editing until final versioning is decided.
+
+---
+
+### Task 1: Create Implementation Branch And Link Issue
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Create a dedicated branch**
+
+Run:
+
+```powershell
+git switch -c feat/rail-label-generation-improvements
+```
+
+Expected: branch created from the current HEAD.
+
+- [ ] **Step 2: Confirm issue link**
+
+Run:
+
+```powershell
+git status --short
+```
+
+Expected: existing unrelated dirty files may remain, but no rail implementation files are changed yet.
+
+- [ ] **Step 3: Commit status**
+
+No commit for branch creation. Subsequent commits should reference `#42` in the body when useful.
+
+### Task 2: Train Input Parser
+
+**Files:**
+- Create: `core/src/main/java/com/tbg/wms/core/rail/RailTrainInputParser.java`
+- Create: `core/src/test/java/com/tbg/wms/core/rail/RailTrainInputParserTest.java`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Test cases:
+
+```java
+@Test
+void parse_shouldAcceptConfiguredDelimitersAndPreserveOrder() {
+    RailTrainInputParser parser = new RailTrainInputParser();
+
+    assertEquals(
+            List.of("JC04152026", "JC05012026", "JC06012026"),
+            parser.parse("jc04152026, JC05012026 / jc06012026")
+    );
+}
+
+@Test
+void parse_shouldDeduplicateAndRejectEmptyInput() {
+    RailTrainInputParser parser = new RailTrainInputParser();
+
+    assertEquals(List.of("JC04152026"), parser.parse("JC04152026; jc04152026"));
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> parser.parse(" , / ; "));
+    assertEquals("At least one train ID is required.", ex.getMessage());
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailTrainInputParserTest test
+```
+
+Expected: FAIL because the parser class does not exist.
+
+- [ ] **Step 3: Implement parser**
+
+Implementation rules:
+
+```java
+public final class RailTrainInputParser {
+    private static final Pattern DELIMITERS = Pattern.compile("[,\\s:/;]+");
+
+    public List<String> parse(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("At least one train ID is required.");
+        }
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        for (String token : DELIMITERS.split(input.trim())) {
+            String normalized = token.trim().toUpperCase(Locale.ROOT);
+            if (!normalized.isEmpty()) {
+                values.add(normalized);
+            }
+        }
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("At least one train ID is required.");
+        }
+        return List.copyOf(values);
+    }
+}
+```
+
+- [ ] **Step 4: Run parser tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailTrainInputParserTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit parser**
+
+```powershell
+git add core/src/main/java/com/tbg/wms/core/rail/RailTrainInputParser.java core/src/test/java/com/tbg/wms/core/rail/RailTrainInputParserTest.java
+git commit -m "feat(rail): parse multiple train codes"
+```
+
+### Task 3: Physical Sheet Layout Class
+
+**Files:**
+- Create: `core/src/main/java/com/tbg/wms/core/rail/RailLabelSheetLayout.java`
+- Create: `core/src/test/java/com/tbg/wms/core/rail/RailLabelSheetLayoutTest.java`
+
+- [ ] **Step 1: Write failing layout tests**
+
+Test cases:
+
+```java
+@Test
+void defaultLayout_shouldUseApprovedPhysicalMedia() {
+    RailLabelSheetLayout layout = RailLabelSheetLayout.defaultLayout();
+
+    assertEquals(612.0f, layout.pageWidthPoints(), 0.001f);
+    assertEquals(792.0f, layout.pageHeightPoints(), 0.001f);
+    assertEquals(288.0f, layout.labelWidthPoints(), 0.001f);
+    assertEquals(144.0f, layout.labelHeightPoints(), 0.001f);
+    assertEquals(10, layout.slotsPerPage());
+}
+
+@Test
+void slotBounds_shouldMatchTwoByFiveSheet() {
+    RailLabelSheetLayout layout = RailLabelSheetLayout.defaultLayout();
+
+    RailLabelSheetLayout.LabelSlot first = layout.slot(0);
+    RailLabelSheetLayout.LabelSlot second = layout.slot(1);
+    RailLabelSheetLayout.LabelSlot rowTwo = layout.slot(2);
+
+    assertEquals(11.25f, first.left(), 0.001f);
+    assertEquals(648.0f, first.bottom(), 0.001f);
+    assertEquals(312.75f, second.left(), 0.001f);
+    assertEquals(648.0f, second.bottom(), 0.001f);
+    assertEquals(11.25f, rowTwo.left(), 0.001f);
+    assertEquals(504.0f, rowTwo.bottom(), 0.001f);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailLabelSheetLayoutTest test
+```
+
+Expected: FAIL because class does not exist.
+
+- [ ] **Step 3: Implement layout with detailed Javadoc**
+
+Required Javadoc content:
+
+- 8.5 by 11 inch portrait page.
+- 4 by 2 inch labels.
+- Left/right margins 5/32 inch.
+- Top/bottom margins 0.5 inch.
+- Center gap 3/16 inch.
+- Validation formulas:
+  - `(4.0 * 2) + 0.1875 + (0.15625 * 2) = 8.5`
+  - `(2.0 * 5) + (0.5 * 2) = 11.0`
+- PDFBox point conversion: `points = inches * 72`.
+- 300 DPI reference calculations for maintainers.
+
+Keep the class focused on layout only. No fonts, no card data, no PDF rendering.
+
+- [ ] **Step 4: Run layout tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailLabelSheetLayoutTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit layout**
+
+```powershell
+git add core/src/main/java/com/tbg/wms/core/rail/RailLabelSheetLayout.java core/src/test/java/com/tbg/wms/core/rail/RailLabelSheetLayoutTest.java
+git commit -m "feat(rail): document label sheet layout"
+```
+
+### Task 4: Renderer Typography And Layout Refactor
+
+**Files:**
+- Modify: `core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java`
+- Optional create: `core/src/main/java/com/tbg/wms/core/rail/RailLabelTypography.java`
+- Modify: `core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java`
+
+- [ ] **Step 1: Add failing renderer tests**
+
+Add tests for:
+
+- 11 cards create 2 PDF pages.
+- Renderer can render a representative card with large CAN/DOM text without throwing.
+- Alignment template still creates one page.
+
+Example:
+
+```java
+@Test
+void renderPdf_shouldPaginateAfterTenCards() throws Exception {
+    Path output = Files.createTempFile("rail-cards-pagination", ".pdf");
+    new RailCardRenderer().renderPdf(cards(11), output);
+
+    try (PDDocument doc = PDDocument.load(output.toFile())) {
+        assertEquals(2, doc.getNumberOfPages());
+    }
+}
+```
+
+- [ ] **Step 2: Run renderer tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailCardRendererTest test
+```
+
+Expected: existing tests pass; new test may pass already for pagination, but layout/typography assertions remain pending through implementation review.
+
+- [ ] **Step 3: Refactor renderer to depend on layout**
+
+Required behavior:
+
+- Default constructor uses `RailLabelSheetLayout.defaultLayout()`.
+- Calibration constructor keeps existing config support for center gap and offsets.
+- Slot math comes from layout, not duplicated renderer constants.
+- Border is 1 to 2 px equivalent in points and uses rounded corners if PDFBox primitive support is practical; otherwise use rectangular border and document limitation.
+
+- [ ] **Step 4: Add large typography**
+
+Use PDFBox Type 1 font equivalents:
+
+- Sequence: `HELVETICA_BOLD_OBLIQUE`, 18 pt, underline drawn manually.
+- Vehicle/product code: `HELVETICA_BOLD_OBLIQUE`, 30 pt, right-aligned, underline drawn manually.
+- Route/load header: `HELVETICA_OBLIQUE`, 8 pt.
+- Door/lane: `HELVETICA_BOLD`, 9 pt when available.
+- Item rows: `HELVETICA`, 8 pt, shrink no lower than 6 pt for more rows.
+- Primary count: `HELVETICA_BOLD`, 30 pt, centered.
+- Secondary count: `HELVETICA_BOLD_OBLIQUE`, 22 pt, centered and underlined when applicable.
+- Footer labels: `HELVETICA_BOLD`, 8 pt, bottom-aligned with writable underline.
+
+- [ ] **Step 5: Run renderer tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailCardRendererTest,RailLabelSheetLayoutTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit renderer**
+
+```powershell
+git add core/src/main/java/com/tbg/wms/core/rail/RailCardRenderer.java core/src/main/java/com/tbg/wms/core/rail/RailLabelTypography.java core/src/test/java/com/tbg/wms/core/rail/RailCardRendererTest.java
+git commit -m "feat(rail): enlarge rail label typography"
+```
+
+If `RailLabelTypography.java` is not created, omit it from `git add`.
+
+### Task 5: Core Multi-Train Workflow
+
+**Files:**
+- Modify: `core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java`
+- Modify: `core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java`
+
+- [ ] **Step 1: Write failing multi-train workflow tests**
+
+Add tests:
+
+```java
+@Test
+void prepareAll_shouldPreserveInputOrderThenCardOrder() {
+    RailWorkflowService service = new RailWorkflowService(fakeRepositoryForTwoTrains());
+
+    RailWorkflowService.RailWorkflowBatchResult result =
+            service.prepareAll(List.of("TRAINB", "TRAINA"));
+
+    assertEquals(List.of("TRAINB", "TRAINA"), result.getTrainIds());
+    assertEquals("TRAINB", result.getCards().get(0).getTrainId());
+    assertEquals("TRAINA", result.getCards().get(1).getTrainId());
+}
+
+@Test
+void prepareAll_shouldFailWhenAnyTrainIsMissing() {
+    RailWorkflowService service = new RailWorkflowService(repositoryMissingSecondTrain());
+
+    IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.prepareAll(List.of("TRAIN1", "MISSING"))
+    );
+
+    assertTrue(ex.getMessage().contains("MISSING"));
+}
+```
+
+- [ ] **Step 2: Run workflow tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailWorkflowServiceTest test
+```
+
+Expected: FAIL because batch result/API does not exist.
+
+- [ ] **Step 3: Implement batch result**
+
+Add a nested immutable `RailWorkflowBatchResult` with:
+
+- `List<String> getTrainIds()`
+- `List<RailWorkflowResult> getResults()`
+- `List<RailStopRecord> getRawRows()`
+- `List<RailCarAggregate> getAggregates()`
+- `List<RailCarCard> getCards()`
+- Combined footprint/missing diagnostics as needed.
+
+Do not change existing `RailWorkflowResult` constructor behavior except where needed for testability.
+
+- [ ] **Step 4: Implement `prepareAll(List<String>)`**
+
+Rules:
+
+- Reject null/empty list.
+- Normalize through existing `prepare(String)` path or shared normalization.
+- Call `prepare` per train in input order.
+- Let strict failures identify the train code.
+- Flatten cards in input order.
+
+- [ ] **Step 5: Run workflow tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core -Dtest=RailWorkflowServiceTest,RailTrainInputParserTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit workflow**
+
+```powershell
+git add core/src/main/java/com/tbg/wms/core/rail/RailWorkflowService.java core/src/test/java/com/tbg/wms/core/rail/RailWorkflowServiceTest.java
+git commit -m "feat(rail): prepare multiple trains"
+```
+
+### Task 6: GUI Printable Table Model
+
+**Files:**
+- Create: `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModel.java`
+- Create: `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModelTest.java`
+
+- [ ] **Step 1: Write failing table model tests**
+
+Test cases:
+
+```java
+@Test
+void setCards_shouldDefaultAllRowsToPrintable() {
+    RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+
+    model.setCards(List.of(card("1"), card("2")));
+
+    assertEquals(2, model.getRowCount());
+    assertEquals(Boolean.TRUE, model.getValueAt(0, 0));
+    assertEquals(2, model.selectedCards().size());
+}
+
+@Test
+void selectionActions_shouldUpdatePrintableRows() {
+    RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+    model.setCards(List.of(card("1"), card("2"), card("3")));
+
+    model.clearAllPrintable();
+    assertTrue(model.selectedCards().isEmpty());
+
+    model.setAllPrintable();
+    model.invertPrintable();
+    assertTrue(model.selectedCards().isEmpty());
+}
+```
+
+- [ ] **Step 2: Run GUI model tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl gui -Dtest=RailPrintableCardTableModelTest test
+```
+
+Expected: FAIL because class does not exist.
+
+- [ ] **Step 3: Implement table model**
+
+Columns:
+
+1. `PRINT` Boolean editable checkbox.
+2. `TRAIN`
+3. `SEQ`
+4. `VEHICLE`
+5. `CAN`
+6. `DOM`
+7. `KEV`
+8. `LOAD_NBR`
+
+Methods:
+
+- `setCards(List<RailCarCard> cards)`
+- `RailCarCard cardAt(int modelRow)`
+- `List<RailCarCard> selectedCards()`
+- `int selectedCount()`
+- `int totalCount()`
+- `void setAllPrintable()`
+- `void clearAllPrintable()`
+- `void invertPrintable()`
+- `void togglePrintableRows(int[] modelRows)`
+
+- [ ] **Step 4: Run table model tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl gui -Dtest=RailPrintableCardTableModelTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit table model**
+
+```powershell
+git add gui/src/main/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModel.java gui/src/test/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModelTest.java
+git commit -m "feat(gui): track printable rail rows"
+```
+
+### Task 7: GUI Multi-Train Preview And Selected Generation
+
+**Files:**
+- Modify: `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupport.java`
+- Modify: `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogActionSupport.java`
+- Modify: `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java`
+- Modify: `gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java`
+- Modify: `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupportTest.java`
+- Modify: `gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogActionSupportTest.java`
+
+- [ ] **Step 1: Write failing dialog support tests**
+
+Update preview request expectation:
+
+```java
+assertEquals(
+        List.of("JC03182026", "JC04152026"),
+        support.preparePreviewRequest("JC03182026, JC04152026").trainIds()
+);
+```
+
+Add generation validation:
+
+```java
+IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> support.prepareGenerationRequest(job, List.of(), "", printer, false, false)
+);
+assertEquals("Select at least one rail row to generate.", ex.getMessage());
+```
+
+- [ ] **Step 2: Run affected GUI tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl gui -Dtest=RailDialogExecutionSupportTest,RailDialogActionSupportTest test
+```
+
+Expected: FAIL due old request shape and generation signature.
+
+- [ ] **Step 3: Update GUI service**
+
+Changes:
+
+- `prepareRailJob(String trainId)` becomes `prepareRailJob(List<String> trainIds)` or overloads with a new method.
+- Use core `RailWorkflowService.prepareAll(trainIds)`.
+- `PreparedRailJob` stores batch result.
+- `generatePdf(PreparedRailJob job, List<RailCarCard> selectedCards, Path outputDir, String printerId)` renders selected cards.
+- File naming uses first train plus `-plus-N` for additional trains.
+
+- [ ] **Step 4: Update dialog support**
+
+Changes:
+
+- `PreviewRequest` stores `List<String> trainIds`.
+- Use `RailTrainInputParser`.
+- `GenerationRequest` accepts selected-card count or selected cards.
+- Reject zero selected cards.
+
+- [ ] **Step 5: Update dialog UI**
+
+Changes:
+
+- Replace `DefaultTableModel` with `RailPrintableCardTableModel`.
+- Set `previewTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION)`.
+- Add buttons near preview table: `Select All`, `Clear All`, `Invert`.
+- Wire buttons to table model.
+- Use selected printable cards for `generate`.
+- Convert selected view rows to model rows before toggling any highlighted-row operation.
+- Keep card preview based on highlighted row, not printable checkbox state.
+
+- [ ] **Step 6: Run GUI rail tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl gui -Dtest="com.tbg.wms.cli.gui.rail.*Test" test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit GUI workflow**
+
+```powershell
+git add gui/src/main/java/com/tbg/wms/cli/gui/rail gui/src/test/java/com/tbg/wms/cli/gui/rail
+git commit -m "feat(gui): select rail rows before printing"
+```
+
+### Task 8: CLI Multi-Train Support
+
+**Files:**
+- Modify: `cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCommand.java`
+- Modify: `cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupport.java`
+- Modify: `cli/src/test/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupportTest.java`
+
+- [ ] **Step 1: Write failing CLI support tests**
+
+Add tests for:
+
+- `--train` accepting delimiter syntax.
+- Preview text showing train count or train IDs.
+- Single-train validation remains accepted.
+
+- [ ] **Step 2: Run CLI support tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl cli -Dtest=RailPrintCliSupportTest test
+```
+
+Expected: FAIL where new parsing/formatting is expected.
+
+- [ ] **Step 3: Update CLI command**
+
+Changes:
+
+- Parse `trainId` with `RailTrainInputParser`.
+- Call `RailWorkflowService.prepareAll(trainIds)`.
+- Generate one combined PDF.
+- Keep all cards included in CLI output.
+- Update generated filename for multiple trains.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl cli -Dtest=RailPrintCliSupportTest,RailPrintCommandTest test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit CLI support**
+
+```powershell
+git add cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCommand.java cli/src/main/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupport.java cli/src/test/java/com/tbg/wms/cli/commands/rail/RailPrintCliSupportTest.java
+git commit -m "feat(cli): generate rail labels for multiple trains"
+```
+
+### Task 9: Documentation And Release Notes
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Optional modify: `README.md` or `INSTRUCTIONS_RAILCAR.md` if they already document rail print workflow.
+
+- [ ] **Step 1: Inspect docs format**
+
+Run:
+
+```powershell
+Get-Content -LiteralPath CHANGELOG.md -TotalCount 80
+```
+
+Expected: identify existing changelog style.
+
+- [ ] **Step 2: Add logical user-facing note**
+
+Content should mention:
+
+- Larger rail label text.
+- Multi-train input delimiters.
+- Combined PDF output.
+- GUI row selection before generating/printing.
+- Issue `#42`.
+
+- [ ] **Step 3: Commit docs**
+
+```powershell
+git add CHANGELOG.md README.md INSTRUCTIONS_RAILCAR.md
+git commit -m "docs(rail): document label generation improvements"
+```
+
+Only add docs that actually changed.
+
+### Task 10: Verification
+
+**Files:**
+- No direct edits expected unless verification finds issues.
+
+- [ ] **Step 1: Run focused rail tests**
+
+Run:
+
+```powershell
+.\mvnw.cmd -pl core,gui,cli -Dtest="*Rail*Test" test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+
+```powershell
+.\mvnw.cmd test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Generate a local sample PDF if test data permits**
+
+Use an existing safe smoke path or documented rail command if WMS access is available. If live WMS is unavailable, rely on renderer tests and note the limitation.
+
+- [ ] **Step 4: Review git history**
+
+Run:
+
+```powershell
+git log --oneline --decorate -8
+git status --short
+```
+
+Expected:
+
+- Logical conventional commits.
+- Only intended files changed for this branch.
+- Unrelated pre-existing dirty files still not touched.
+
+- [ ] **Step 5: Update issue**
+
+Add a GitHub issue comment summarizing verification results and any known limitations.
+
+### Task 11: Final Approval And PR
+
+**Files:**
+- No direct edits expected.
+
+- [ ] **Step 1: Present final result to user**
+
+Include:
+
+- Changed behavior.
+- Commit list.
+- Test evidence.
+- Any limitations, especially live WMS/manual print verification if not run.
+
+- [ ] **Step 2: Wait for user approval**
+
+Do not open PR until the user approves the shippable result.
+
+- [ ] **Step 3: Push branch**
+
+Run after approval:
+
+```powershell
+git push -u origin feat/rail-label-generation-improvements
+```
+
+- [ ] **Step 4: Create PR**
+
+Create PR against the repository default branch with:
+
+- Conventional title, for example `feat(rail): improve label generation workflow`
+- Link to `Closes #42`
+- Summary of behavior changes
+- Test evidence
+- Screenshots or generated PDF reference if available
+
+Expected: PR is open for final review.
+

--- a/docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md
+++ b/docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md
@@ -129,6 +129,19 @@ HKLM\SOFTWARE\ODBC\ODBC.INI
 
 The driver detection must reject 32-bit driver names such as `Oracle in OraClient19Home1_32bit`. DSNs must not include `UID`, `PWD`, or any credential-like value.
 
+## Optional Credential Smoke Test
+
+The SOP confirms that credentials are not part of `tnsnames.ora` and are not required to create the System DSNs. Credentials are used when Net Configuration Assistant or ODBC Administrator tests the connection, and the Excel Analyzer connection strings embed `DSN`, `UID`, `PWD`, and `DBQ`.
+
+The installer may support an optional internal smoke test mode that uses the read-only report credentials in memory after DSN creation:
+
+```text
+Username: RPTADM
+Password: supplied by IT build/deployment configuration
+```
+
+This mode should attempt an actual login against each alias or DSN and report pass/fail per site. It must not write `UID` or `PWD` into the System DSNs, `tnsnames.ora`, install state, command lines, or generated response files. Logs may identify the username and test result, for example `TBG3002 credential test passed as RPTADM`, but should not print the password because the exact password value adds no diagnostic value to install logs.
+
 ## Detection And Verification
 
 `detect.ps1` and the installer's post-install verification share the same checks:
@@ -140,6 +153,8 @@ The driver detection must reject 32-bit driver names such as `Oracle in OraClien
 - Each DSN points to its matching alias or server name.
 
 Verification should continue collecting results after a failure when possible, so Intune logs show a useful report instead of only the first symptom. Optional TCP reachability checks to port `1521` may be supported as non-blocking warnings because VPN, firewall, and network location may vary at install time.
+
+Optional credential smoke tests are verification-only and should be separately controllable from structural detection. `detect.ps1` should continue to verify installed state without requiring live database access or credentials.
 
 ## Uninstall Behavior
 
@@ -161,7 +176,7 @@ Install state is written to:
 C:\ProgramData\Tropicana\ODBCSetup
 ```
 
-The installer must never write database usernames or passwords to disk, registry, command logs, transcript logs, DSNs, or generated config. Logs should avoid full registry dumps and full future command lines that could include secrets if credential options are ever added.
+The installer must never write database passwords to disk, registry, command logs, transcript logs, DSNs, or generated config. Usernames may appear in logs for optional credential smoke test status. Logs should avoid full registry dumps and full future command lines that could include secrets.
 
 ## Error Handling
 
@@ -185,6 +200,7 @@ Automated tests should validate pure script behavior without requiring Oracle to
 - generated `tnsnames.ora` includes all seven aliases, hosts, port `1521`, and service `WMSP`
 - response-file patching sets Oracle Home, Oracle Base, install type, and built-in account
 - DSN cmdlet and registry payload generation omit credentials
+- optional credential smoke test logging includes username/test status but omits password
 - detection logic reports missing and present components clearly
 - packaging refuses to build when the Oracle ZIP path is missing
 - generated local artifacts are placed under `dist/odbc-setup`

--- a/docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md
+++ b/docs/superpowers/specs/2026-05-15-oracle-odbc-setup-design.md
@@ -1,0 +1,205 @@
+# Oracle ODBC Setup Installer Design
+
+Date: 2026-05-15
+
+## Goal
+
+Build a Windows setup package that prepares a company-managed PC for Oracle 19c 64-bit ODBC connectivity to all Warehouse Analyzer sites. The package is intended for Intune / Company Portal deployment and may run elevated through Intune even when the logged-in user does not have local administrator rights.
+
+The installer must avoid end-user prerequisites, avoid SharePoint or manual download dependencies, and never store or log database credentials. Oracle installer media may be bundled into the generated local executable, but the Oracle ZIP and generated executable must remain local-only artifacts and must not be committed to git.
+
+## Repo And Artifact Layout
+
+Committed source lives under the existing Windows scripting area:
+
+```text
+scripts/odbc-setup/
+  install.cmd
+  install-odbc.ps1
+  detect.ps1
+  uninstall.ps1
+  build-exe.ps1
+  README.md
+  payload/
+    oracle-client-install.rsp.template
+```
+
+Generated local artifacts live under ignored output paths:
+
+```text
+dist/odbc-setup/
+  Tropicana-Oracle-ODBC-Setup.exe
+  stage/
+    install.cmd
+    install-odbc.ps1
+    detect.ps1
+    uninstall.ps1
+    payload/
+      O19-64bit.zip
+      oracle-client-install.rsp.template
+```
+
+`build-exe.ps1` accepts an `-OracleZipPath` argument and copies that ZIP into the staging payload before building the single-file executable. The staged Oracle ZIP is bundled into the executable but is not committed.
+
+## Packaging Approach
+
+The PowerShell installer is the source of truth. The executable is only a wrapper that extracts the same script bundle and runs `install.cmd`.
+
+`build-exe.ps1` should prefer a reliable single-file wrapper:
+
+1. Compile a small .NET Framework self-extracting launcher with the Windows-provided C# compiler when available.
+2. Optionally use native Windows self-extraction tooling when it is available and reliable on the build machine.
+3. Fail with an actionable message if no supported executable packaging path exists.
+
+The generated executable extracts to a package-owned temporary directory, launches `install.cmd`, preserves logs under `C:\ProgramData\Tropicana\ODBCSetup\Logs`, forwards the installer exit code, and removes temporary extraction files.
+
+## Installer Flow
+
+`install.cmd` launches 64-bit Windows PowerShell with local execution policy bypass and forwards control to `install-odbc.ps1`.
+
+`install-odbc.ps1` performs these steps:
+
+1. Require 64-bit Windows PowerShell.
+2. Detect elevation and fail clearly if launched manually without administrator rights.
+3. Create `C:\ProgramData\Tropicana\ODBCSetup` and `C:\ProgramData\Tropicana\ODBCSetup\Logs`.
+4. Expand bundled `payload\O19-64bit.zip` into a package-owned temporary folder.
+5. Generate an Oracle response file from the bundled template with:
+   - `ORACLE_BASE=C:\App\Client\Oracle`
+   - `ORACLE_HOME=C:\App\Client\Oracle\Product\19.0.0\Client_1`
+   - `oracle.install.IsBuiltInAccount=true`
+   - `oracle.install.client.installType=Administrator`
+6. Run Oracle `setup.exe` silently and capture the exit code and Oracle log location.
+7. Treat an already-installed matching Oracle Home as idempotent and repairable rather than fatal.
+8. Write `tnsnames.ora` directly to `C:\App\Client\Oracle\Product\19.0.0\Client_1\Network\Admin\tnsnames.ora`.
+9. Detect the installed 64-bit Oracle ODBC driver dynamically.
+10. Create or repair seven 64-bit System DSNs.
+11. Run verification and return a nonzero exit code if required checks fail.
+
+## Site Configuration
+
+The installer writes these aliases to `tnsnames.ora`, all using TCP port `1521` and service name `WMSP`:
+
+| Alias | Site | Host |
+| --- | --- | --- |
+| TBG1000 | Bradenton | 10.18.228.52 |
+| TBG1010 | City of Industry | 10.19.96.103 |
+| TBG1011 | Fort Pierce | 10.18.228.72 |
+| TBG1279 | Kevita | 10.19.96.104 |
+| TBG3002 | Jersey | 10.19.68.61 |
+| TBG3230 | Midwest | 10.18.228.66 |
+| TBG3322 | Walnut | 10.19.68.53 |
+
+Each entry uses this shape:
+
+```text
+TBG1000 =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 10.18.228.52)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVICE_NAME = WMSP)
+    )
+  )
+```
+
+## DSN Creation
+
+The installer creates these 64-bit System DSNs:
+
+```text
+TBG1000
+TBG1010
+TBG1011
+TBG1279
+TBG3002
+TBG3230
+TBG3322
+```
+
+It should prefer PowerShell's built-in ODBC cmdlets when they work for the installed Oracle driver:
+
+```powershell
+Add-OdbcDsn -Name TBG1000 -DriverName "Oracle in OraClient19Home1" -DsnType System -Platform "64-bit" -SetPropertyValue @("ServerName=TBG1000")
+```
+
+If the cmdlets are unavailable or do not persist the required Oracle values, it should fall back to writing the standard 64-bit ODBC registry keys under:
+
+```text
+HKLM\SOFTWARE\ODBC\ODBC.INI
+```
+
+The driver detection must reject 32-bit driver names such as `Oracle in OraClient19Home1_32bit`. DSNs must not include `UID`, `PWD`, or any credential-like value.
+
+## Detection And Verification
+
+`detect.ps1` and the installer's post-install verification share the same checks:
+
+- Oracle Home path exists.
+- 64-bit Oracle ODBC driver is registered.
+- `tnsnames.ora` exists and contains all seven aliases.
+- All seven 64-bit System DSNs exist.
+- Each DSN points to its matching alias or server name.
+
+Verification should continue collecting results after a failure when possible, so Intune logs show a useful report instead of only the first symptom. Optional TCP reachability checks to port `1521` may be supported as non-blocking warnings because VPN, firewall, and network location may vary at install time.
+
+## Uninstall Behavior
+
+`uninstall.ps1` removes package-owned DSNs and package-owned metadata by default. It should not remove the Oracle client by default because that client may be shared by other tools.
+
+Oracle client removal may be added behind an explicit switch for IT-controlled scenarios, but it must not be part of the default Company Portal uninstall path.
+
+## Logging And Security
+
+Logs are written to:
+
+```text
+C:\ProgramData\Tropicana\ODBCSetup\Logs
+```
+
+Install state is written to:
+
+```text
+C:\ProgramData\Tropicana\ODBCSetup
+```
+
+The installer must never write database usernames or passwords to disk, registry, command logs, transcript logs, DSNs, or generated config. Logs should avoid full registry dumps and full future command lines that could include secrets if credential options are ever added.
+
+## Error Handling
+
+The installer returns nonzero exit codes for these conditions:
+
+- missing payload ZIP
+- not elevated
+- wrong PowerShell architecture
+- Oracle installer failure
+- Oracle ODBC driver not found after install
+- unable to write Oracle network admin files
+- unable to create or repair one or more DSNs
+- verification failed after attempted repair
+
+Error messages should name the failed operation, affected path or DSN, and relevant log path.
+
+## Testing
+
+Automated tests should validate pure script behavior without requiring Oracle to be installed:
+
+- generated `tnsnames.ora` includes all seven aliases, hosts, port `1521`, and service `WMSP`
+- response-file patching sets Oracle Home, Oracle Base, install type, and built-in account
+- DSN cmdlet and registry payload generation omit credentials
+- detection logic reports missing and present components clearly
+- packaging refuses to build when the Oracle ZIP path is missing
+- generated local artifacts are placed under `dist/odbc-setup`
+
+Manual validation should run on a clean Windows VM through elevated PowerShell or Intune test deployment:
+
+- install from the generated executable
+- verify Intune detection succeeds
+- verify 64-bit ODBC Administrator shows all seven System DSNs
+- verify an Analyzer can connect when credentials are supplied interactively
+- rerun installer and confirm idempotent repair with no duplicate DSNs
+- run uninstall and confirm DSNs are removed while Oracle client remains installed by default
+
+## Open Decisions
+
+- Confirm the exact executable wrapper implementation after checking build-machine support for `csc.exe` and native self-extraction tooling.
+- Confirm whether optional TCP reachability warnings should be enabled by default in logs.
+- Confirm whether IT wants an explicit `-RemoveOracleClient` uninstall switch in the first implementation or later.

--- a/docs/superpowers/specs/2026-05-29-rail-label-generation-design.md
+++ b/docs/superpowers/specs/2026-05-29-rail-label-generation-design.md
@@ -1,0 +1,265 @@
+# Rail Label Generation Improvements Design
+
+Date: 2026-05-29
+
+## Purpose
+
+Improve rail label generation so operators can:
+
+- Render more readable 4 inch by 2 inch rail labels.
+- Enter multiple train codes at once.
+- Preview all generated railcar rows before output.
+- Explicitly choose which rows are included in the generated PDF and print job.
+
+The generated PDF remains one combined document. Cards are ordered by train-code input order, then by the existing deterministic railcar/card order for each train.
+
+## Existing Context
+
+The rail workflow is already split across:
+
+- `core/src/main/java/com/tbg/wms/core/rail`: WMS rail data aggregation, card planning, PDF rendering, and print support.
+- `cli/src/main/java/com/tbg/wms/cli/commands/rail`: command-line rail print entry points.
+- `gui/src/main/java/com/tbg/wms/cli/gui/rail`: Swing rail-label dialog, preview table, diagnostics, PDF generation, and print actions.
+
+The current renderer already emits letter-sized PDFs with a 2 column by 5 row grid, but typography is too small and the sheet measurements are implicit in renderer constants. The new work should make physical-media assumptions explicit and isolated.
+
+## Physical Media
+
+Future maintainers need to see the physical label-stock math in code documentation, not only in external notes. The media specification belongs on the class that owns sheet geometry, proposed as `RailLabelSheetLayout`.
+
+Sheet:
+
+- Page width: 8.5 inches
+- Page height: 11.0 inches
+- Orientation: portrait
+- Columns: 2
+- Rows: 5
+- Labels per sheet: 10
+
+Label:
+
+- Width: 4.0 inches
+- Height: 2.0 inches
+
+Margins and gap:
+
+- Left margin: 5/32 inch, or 0.15625 inch
+- Right margin: 5/32 inch, or 0.15625 inch
+- Top margin: 0.5 inch
+- Bottom margin: 0.5 inch
+- Center gap: 3/16 inch, or 0.1875 inch
+
+Validation:
+
+```text
+(4.0 * 2) + 0.1875 + (0.15625 * 2) = 8.5
+(2.0 * 5) + (0.5 * 2) = 11.0
+```
+
+PDFBox uses points, not pixels. The implementation should store values in inches, then convert to points at render time:
+
+```text
+points = inches * 72
+```
+
+For comparison with 300 DPI print previews:
+
+```text
+pixels = inches * 300
+
+Page:  8.5 * 300 = 2550 px, 11 * 300 = 3300 px
+Label: 4.0 * 300 = 1200 px, 2 * 300 = 600 px
+Left/right margin: 0.15625 * 300 = 46.875 px, rounded 47 px
+Center gap: 0.1875 * 300 = 56.25 px, rounded 56 px
+Top/bottom margin: 0.5 * 300 = 150 px
+```
+
+The 300 DPI reference coordinates are:
+
+```text
+Row 1 Col 1: x=47,   y=150
+Row 1 Col 2: x=1303, y=150
+Row 2 Col 1: x=47,   y=750
+Row 2 Col 2: x=1303, y=750
+Row 3 Col 1: x=47,   y=1350
+Row 3 Col 2: x=1303, y=1350
+Row 4 Col 1: x=47,   y=1950
+Row 4 Col 2: x=1303, y=1950
+Row 5 Col 1: x=47,   y=2550
+Row 5 Col 2: x=1303, y=2550
+```
+
+## Typography
+
+The renderer should use centralized typography constants, expressed in points:
+
+| Element | Default | Style |
+| --- | ---: | --- |
+| Sequence number | 18 pt | Bold, italic, underlined |
+| Main rail car/product code | 30 pt | Bold, italic, underlined, right-aligned |
+| Route/header line | 8 pt | Italic |
+| Door/lane code | 9 pt | Bold |
+| Item/quantity rows | 8 pt | Regular or medium |
+| Primary CAN/DOM count | 30 pt | Bold, centered |
+| Secondary CAN/DOM count | 22 pt | Bold, italic, underlined, centered |
+| Footer fields | 8 pt | Bold, underlined labels with writable underline |
+
+Visual priority:
+
+1. Rail car/product code and CAN/DOM count.
+2. Sequence number.
+3. Item quantities and routing information.
+4. PASS/FUEL/BH handwritten-entry fields.
+
+Rendering placement:
+
+- Sequence number: top-left, underlined, bold, italic.
+- Rail car/product code: top-right, right-aligned, underlined, bold, italic.
+- Route/load header: upper-left supporting text.
+- Door/lane code: below route/header when available.
+- Item rows: left body area, capped at 5 visible rows.
+- Primary destination count: centered in the open body area.
+- Secondary destination count: centered directly below primary count when applicable.
+- Footer: bottom edge as `PASS:_____   FUEL:_____   BH:_____`, with about 0.5 inch of writable underline per field.
+
+If more than 5 item rows exist, reduce the item font proportionally but not below 6 pt. If the text still cannot fit, truncate and show continuation text.
+
+## Multiple Train Input
+
+Add a small parser with one responsibility: turning operator text into normalized train IDs.
+
+Proposed class: `RailTrainInputParser`.
+
+Rules:
+
+- Accept comma, whitespace, colon, slash, semicolon, or any combination as separators.
+- Trim each token.
+- Normalize to uppercase.
+- Drop blank tokens.
+- Deduplicate while preserving first occurrence order.
+- Reject input that produces no train IDs.
+
+Examples:
+
+```text
+JC04152026, JC05012026
+JC04152026 JC05012026
+JC04152026/JC05012026
+JC04152026: JC05012026; JC06012026
+```
+
+All examples should produce ordered train IDs.
+
+## Combined Workflow
+
+The current core workflow prepares one train. Add a multi-train path without weakening the existing single-train API.
+
+Proposed behavior:
+
+- Existing `prepare(String trainId)` remains the single-train primitive.
+- New `prepareAll(List<String> trainIds)` or equivalent calls the single-train primitive per train.
+- Combined result stores:
+  - Ordered train IDs.
+  - Per-train result details.
+  - Flattened card list in print order.
+  - Combined diagnostics.
+  - Per-train failures with enough context for GUI/CLI messaging.
+
+Failure policy should be strict by default: if any requested train has no WMS rows or cannot prepare, the preview should fail before generating a PDF. This avoids silently skipping a train an operator typed.
+
+## Row Selection
+
+Operators must control which preview rows become labels.
+
+Recommended GUI behavior:
+
+- Preview table includes a `PRINT` checkbox column.
+- All generated rows default to checked after preview load.
+- Normal table multi-selection should support Ctrl-click and Shift-click through `JTable.MULTIPLE_INTERVAL_SELECTION`.
+- Add compact controls:
+  - `Select All`
+  - `Clear All`
+  - `Invert`
+- Toggling the `PRINT` checkbox on one row affects that row.
+- Pressing Space or using a toolbar action should toggle the checkbox state for all highlighted rows when practical.
+- Generate PDF and Print actions use only checked rows.
+- If zero rows are checked, generation is blocked with a clear message.
+
+Selection state should not live only in highlighted Swing rows. Highlighted rows are transient UI state; the printable choice should be explicit in the table model.
+
+Proposed support type: `RailPrintableCardSelection`, responsible for filtering cards by checked indexes or stable row IDs.
+
+## Output
+
+Multiple train codes generate one PDF:
+
+- File name can include a compact combined identifier, such as `rail-cards-JC04152026-plus-2-YYYYMMDD-HHmmss.pdf`, to avoid extremely long file names.
+- Diagnostics should list all train IDs and the number of cards selected versus total.
+- Print uses the same selected-card PDF.
+
+CLI support can follow after GUI support. For CLI, a minimal first pass is:
+
+- Allow `--train` to accept the same multi-code delimiter syntax.
+- Generate one combined PDF.
+- Keep all rows included because the CLI has no interactive table.
+
+Optional future CLI selection can use explicit sequence filters, but it is not required for this change.
+
+## SRP And SOLID Boundaries
+
+The implementation should preserve strict single responsibility:
+
+- `RailTrainInputParser`: parse train-code text only.
+- `RailLabelSheetLayout`: own physical media, inch values, point conversion, and slot bounds only.
+- `RailLabelTypography`: own font size/style constants only, if this improves clarity.
+- `RailWorkflowService`: orchestrate rail preparation only; no rendering, no Swing, no parser-specific UI behavior.
+- `RailCardRenderer`: render provided cards to a provided PDF path using layout and typography collaborators only.
+- `RailPrintableCardSelection`: filter selected card rows only.
+- `RailLabelsDialog`: assemble Swing components and route user actions only.
+- Dialog support classes: continue holding validation, state transitions, and action outcome formatting instead of growing the dialog.
+
+SOLID implications:
+
+- Single Responsibility: each class above has one reason to change.
+- Open/Closed: sheet geometry and typography can evolve behind renderer collaborators without changing workflow or UI code.
+- Liskov Substitution: keep collaborators simple and behaviorally narrow; avoid subclass-based variation unless a real extension point exists.
+- Interface Segregation: do not introduce broad service interfaces for one implementation; use small package-private collaborators where tests need seams.
+- Dependency Inversion: high-level workflow should not depend on Swing or PDFBox details; rendering-specific classes may depend on PDFBox.
+
+## Testing
+
+Core tests:
+
+- Parser accepts all required delimiters and combinations.
+- Parser normalizes uppercase, trims blanks, dedupes, and rejects empty input.
+- Multi-train workflow preserves input train order and existing card order within each train.
+- Sheet layout returns expected point bounds for 2 by 5 labels.
+- 300 DPI reference math is represented in documentation/tests as needed, while renderer uses point math.
+- Renderer creates one page per 10 selected cards.
+- Renderer handles 0 cards by creating a blank letter page, preserving current behavior unless changed intentionally.
+
+GUI support tests:
+
+- Preview table defaults all rows to printable.
+- Select all, clear all, and invert update the printable checkbox state.
+- Generation request blocks when no rows are printable.
+- Generation passes only checked cards to the GUI workflow service.
+
+Regression tests:
+
+- Existing single-train CLI behavior still works.
+- Alignment template still uses the configured physical media.
+- Printer routing behavior is unchanged.
+
+## Implementation Notes
+
+This change should avoid broad refactoring. The highest-value path is:
+
+1. Add parser and tests.
+2. Add sheet layout class with detailed physical-media Javadoc and tests.
+3. Refactor renderer to use layout and new typography constants.
+4. Add multi-train preparation in core and GUI bridge.
+5. Add explicit printable checkbox state and multi-select controls to the GUI.
+6. Route generation through selected cards only.
+7. Add CLI multi-train input support if scope allows in the same implementation pass.
+

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tbg.wms</groupId>
         <artifactId>wms-pallet-tag-system</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gui</artifactId>

--- a/gui/src/main/java/com/tbg/wms/cli/gui/AdvancedSettingsDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/AdvancedSettingsDialog.java
@@ -70,6 +70,7 @@ final class AdvancedSettingsDialog extends JDialog {
         selector.add(reloadButton);
         selector.add(openFolderButton);
         top.add(selector, BorderLayout.NORTH);
+        top.add(GuiHelpSupport.createHelpButton(this, "Advanced Settings", GuiHelpTopics.advancedSettings()), BorderLayout.EAST);
         top.add(new JLabel("Advanced settings edit runtime YAML/CSV/ZPL config files only. Env values remain root-only."), BorderLayout.CENTER);
         top.add(pathLabel, BorderLayout.SOUTH);
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/BarcodeDialogFactory.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/BarcodeDialogFactory.java
@@ -231,6 +231,9 @@ final class BarcodeDialogFactory {
                 }
             }
         });
+        JPanel helpHeader = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpHeader.add(GuiHelpSupport.createHelpButton(dialog, "Barcode Generator", GuiHelpTopics.barcodeGenerator()));
+        dialog.add(helpHeader, BorderLayout.NORTH);
         dialog.add(form, BorderLayout.CENTER);
         dialog.add(buttons, BorderLayout.SOUTH);
         dialog.pack();
@@ -418,6 +421,13 @@ final class BarcodeDialogFactory {
         closeAdvanced.addActionListener(x -> advancedDialog.dispose());
         advancedButtons.add(closeAdvanced);
 
+        JPanel helpHeader = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpHeader.add(GuiHelpSupport.createHelpButton(
+                advancedDialog,
+                "Advanced Barcode Settings",
+                GuiHelpTopics.barcodeAdvancedSettings()
+        ));
+        advancedDialog.add(helpHeader, BorderLayout.NORTH);
         advancedDialog.add(advancedForm, BorderLayout.CENTER);
         advancedDialog.add(advancedButtons, BorderLayout.SOUTH);
         advancedDialog.pack();

--- a/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpSupport.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpSupport.java
@@ -1,0 +1,86 @@
+package com.tbg.wms.cli.gui;
+
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import java.awt.Component;
+import java.awt.Font;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Shared presenter for small contextual help dialogs.
+ *
+ * <p>Views own their workflow and shortcut content while this helper owns button creation,
+ * formatting, and display. Keeping those responsibilities separate avoids duplicating Swing
+ * dialog construction across the frame, modal dialogs, and tools.</p>
+ */
+public final class GuiHelpSupport {
+    private static final int HELP_COLUMNS = 64;
+    private static final int HELP_ROWS = 18;
+
+    private GuiHelpSupport() {
+    }
+
+    /**
+     * Creates the standard corner help button for a view or tool.
+     *
+     * @param owner    component used as the help dialog owner
+     * @param title    user-facing view/tool title
+     * @param sections help sections to display
+     * @return configured help button
+     */
+    public static JButton createHelpButton(Component owner, String title, List<HelpSection> sections) {
+        Objects.requireNonNull(title, "title cannot be null");
+        Objects.requireNonNull(sections, "sections cannot be null");
+        JButton helpButton = new JButton("Help");
+        helpButton.setFocusable(false);
+        helpButton.setToolTipText("Show help for " + title);
+        helpButton.addActionListener(e -> showHelp(owner, title, sections));
+        return helpButton;
+    }
+
+    static String formatHelpText(List<HelpSection> sections) {
+        Objects.requireNonNull(sections, "sections cannot be null");
+        StringBuilder builder = new StringBuilder();
+        for (HelpSection section : sections) {
+            if (builder.length() > 0) {
+                builder.append(System.lineSeparator()).append(System.lineSeparator());
+            }
+            builder.append(section.heading()).append(System.lineSeparator());
+            for (String line : section.lines()) {
+                builder.append("- ").append(line).append(System.lineSeparator());
+            }
+        }
+        return builder.toString().stripTrailing();
+    }
+
+    private static void showHelp(Component owner, String title, List<HelpSection> sections) {
+        JTextArea textArea = new JTextArea(formatHelpText(sections), HELP_ROWS, HELP_COLUMNS);
+        textArea.setEditable(false);
+        textArea.setLineWrap(true);
+        textArea.setWrapStyleWord(true);
+        textArea.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 13));
+        textArea.setCaretPosition(0);
+        JOptionPane.showMessageDialog(
+                owner,
+                new JScrollPane(textArea),
+                title + " Help",
+                JOptionPane.INFORMATION_MESSAGE
+        );
+    }
+
+    /**
+     * Immutable help topic section.
+     *
+     * @param heading section heading
+     * @param lines   bullets shown under the heading
+     */
+    public record HelpSection(String heading, List<String> lines) {
+        public HelpSection {
+            Objects.requireNonNull(heading, "heading cannot be null");
+            lines = List.copyOf(Objects.requireNonNull(lines, "lines cannot be null"));
+        }
+    }
+}

--- a/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
@@ -34,9 +34,10 @@ public final class GuiHelpTopics {
     public static List<GuiHelpSupport.HelpSection> railLabels() {
         return List.of(
                 section("Workflow",
-                        "Type one train code, or type several train codes at the same time.",
-                        "For example: 302, 303, 304",
-                        "Other examples that also work: 302 303, 302/303, or 302:303;304",
+                        "Type one full train code, or type several full train codes at the same time.",
+                        "For example: JC05262026",
+                        "For more than one train, type examples like: JC05262026, JC05272026",
+                        "Other examples that also work: JC05262026 JC05272026, JC05262026/JC05272026, or JC05262026:JC05272026;JC05282026",
                         "Click Load Preview to gather the rail rows for every train you entered.",
                         "Click Generate PDF to put the selected rail labels into the same PDF."),
                 section("Row Selection",

--- a/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
@@ -1,0 +1,147 @@
+package com.tbg.wms.cli.gui;
+
+import java.util.List;
+
+/**
+ * Central catalog of operator help text for GUI views and tools.
+ *
+ * <p>Keeping copy here lets windows depend on stable topic methods instead of each view also
+ * owning formatting text. This preserves a single reason to change when shortcuts or workflow
+ * instructions change.</p>
+ */
+public final class GuiHelpTopics {
+    private GuiHelpTopics() {
+    }
+
+    public static List<GuiHelpSupport.HelpSection> mainWindow() {
+        return List.of(
+                section("Workflow",
+                        "Choose Carrier Move ID or Shipment ID, enter the ID, then load the preview.",
+                        "Review the generated label math and label selection before printing.",
+                        "Use Tools for rail labels, barcode generation, ZPL preview, queue print, resume, and settings."),
+                section("Shortcuts",
+                        "Ctrl+F runs Preview when the preview button is enabled.",
+                        "Text fields use terminal-like mouse clipboard behavior where supported."),
+                section("Printing",
+                        "Confirm Print prints only the selected preview labels.",
+                        "Show Labels opens a generated ZPL preview for the currently selected labels.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> railLabels() {
+        return List.of(
+                section("Workflow",
+                        "Enter one or more train codes separated by comma, space, colon, slash, semicolon, or combinations of those characters.",
+                        "Load Preview builds one combined rail label job for all entered trains.",
+                        "Generate PDF creates one PDF containing only rows whose PRINT checkbox is selected."),
+                section("Row Selection",
+                        "All rows are printable by default after preview loads.",
+                        "Ctrl-click adds or removes individual table rows from the current selection.",
+                        "Shift-click selects a row range.",
+                        "Press Space to toggle the PRINT checkbox for selected rows.",
+                        "Select All, Clear All, and Invert update which rail labels will be generated."),
+                section("Shortcuts",
+                        "Ctrl+F runs Load Preview when it is enabled.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> barcodeGenerator() {
+        return List.of(
+                section("Workflow",
+                        "Enter barcode data, choose type, copies, and printer target.",
+                        "Preview opens a live ZPL preview for the current barcode request.",
+                        "Generate prints to the selected printer or writes ZPL when Print to File is selected."),
+                section("Tools",
+                        "Utility Keyboard opens scanner-friendly symbol entry.",
+                        "Advanced Settings adjusts orientation, dimensions, origin, module width, ratio, and human-readable text.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> barcodeAdvancedSettings() {
+        return List.of(
+                section("Workflow",
+                        "Adjust barcode rendering settings for the active barcode request.",
+                        "Use Done to keep the current settings and return to the generator."),
+                section("Units",
+                        "Label width, label height, and origins are in printer dots.",
+                        "Module width, ratio, and barcode height affect scanner readability.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> zplPreview() {
+        return List.of(
+                section("Workflow",
+                        "Paste ZPL or open a .zpl file, then render the preview.",
+                        "Use document controls to move through generated multi-document previews.",
+                        "DPMM, width, height, and label index control how Labelary renders the preview."),
+                section("Shortcuts",
+                        "Enter renders immediately while the ZPL text area is focused.",
+                        "Shift+Enter inserts a new line in the ZPL text area.",
+                        "Render live queues preview updates as the ZPL or render settings change.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> queuePrint() {
+        return List.of(
+                section("Workflow",
+                        "Paste carrier move or shipment IDs separated by new lines or semicolons.",
+                        "Choose the default type for unprefixed IDs.",
+                        "Use C: or S: prefixes when a queue contains mixed carrier moves and shipments."),
+                section("Printing",
+                        "Preview Queue validates and prepares the queue before anything prints.",
+                        "Print Queue prints the prepared queue to the currently selected main-window printer target.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> settings() {
+        return List.of(
+                section("Workflow",
+                        "Set the default print-to-file output directory and generated-output retention policy.",
+                        "Use Update Manager for version visibility and install target selection.",
+                        "Advanced Settings opens editable runtime config files."),
+                section("Maintenance",
+                        "Clean Old Output Now applies the retention policy immediately.",
+                        "Uninstall / Clean Install Prep launches packaged-install maintenance when available.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> advancedSettings() {
+        return List.of(
+                section("Workflow",
+                        "Select an editable config file, change its contents, then Save.",
+                        "Reload discards the editor contents and reloads the current file from disk.",
+                        "Open Config Folder opens the folder containing the selected config file."),
+                section("Scope",
+                        "This editor only changes runtime YAML, CSV, and ZPL config files.",
+                        "Environment secrets stay outside the GUI.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> updates() {
+        return List.of(
+                section("Workflow",
+                        "Refresh reloads the release catalog.",
+                        "Enable experimental / prerelease updates to include prerelease install targets.",
+                        "Select an install target, then Install Selected to launch the configured install action."),
+                section("Release Page",
+                        "Open Release Page opens the selected target release when available.",
+                        "If no target is selected, the latest stable release page is used.")
+        );
+    }
+
+    public static List<GuiHelpSupport.HelpSection> analyzers() {
+        return List.of(
+                section("Workflow",
+                        "Choose an analyzer from the list and Refresh to load current data.",
+                        "Auto refresh repeats the selected analyzer at the chosen interval.",
+                        "Some analyzers render as tables and others render as dashboard panels."),
+                section("Usage",
+                        "Analyzers are intended for developer and operational diagnostics.",
+                        "The status bar reports the active load state and failures.")
+        );
+    }
+
+    private static GuiHelpSupport.HelpSection section(String heading, String... lines) {
+        return new GuiHelpSupport.HelpSection(heading, List.of(lines));
+    }
+}

--- a/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
@@ -16,88 +16,87 @@ public final class GuiHelpTopics {
     public static List<GuiHelpSupport.HelpSection> mainWindow() {
         return List.of(
                 section("Workflow",
-                        "Choose Carrier Move ID or Shipment ID, type or paste the number, then click Preview.",
-                        "For example: choose Shipment ID for 8000582489, or choose Carrier Move ID for a carrier move number.",
-                        "Review the labels that appear before printing.",
-                        "Use Tools for rail labels, barcode generation, ZPL preview, queue print, resume, and settings."),
+                        "Choose Carrier Move ID or Shipment ID, enter the identifier, then run Preview.",
+                        "Review the label set, clear any labels that should stay out of the run, then use Confirm Print.",
+                        "Show Labels opens the generated ZPL preview for the current selected labels.",
+                        "Tools keeps rail labels, barcode generation, ZPL preview, queue print, resume, and settings close to the main workflow."),
                 section("Shortcuts",
-                        "Ctrl+F runs Preview when the preview button is enabled.",
-                        "In text boxes, left-click and drag to highlight text.",
-                        "right-click in a text box to copy, paste, cut, or select all when those options are available.",
-                        "You can also use Ctrl+C to copy, Ctrl+V to paste, and Ctrl+A to select all."),
+                        "Ctrl+F runs Preview when Preview is enabled.",
+                        "Ctrl+A, Ctrl+C, Ctrl+V, and Ctrl+X use standard text-field editing.",
+                        "Tab moves through the active controls; Shift+Tab moves backward."),
                 section("Printing",
-                        "Confirm Print prints only the labels that are still selected.",
-                        "Show Labels lets you look at the generated labels before sending them to the printer.")
+                        "Confirm Print sends only selected labels to the active printer target.",
+                        "Print to file keeps generated labels under the configured output directory.",
+                        "Printer routing and print-to-file targets are visible before the run starts.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> railLabels() {
         return List.of(
                 section("Workflow",
-                        "Type one full train code, or type several full train codes at the same time.",
-                        "For example: JC05262026",
-                        "For more than one train, type examples like: JC05262026, JC05272026",
-                        "Other examples that also work: JC05262026 JC05272026, JC05262026/JC05272026, or JC05262026:JC05272026;JC05282026",
-                        "Click Load Preview to gather the rail rows for every train you entered.",
-                        "Click Generate PDF to put the selected rail labels into the same PDF."),
-                section("Row Selection",
-                        "Every row is checked to print when the preview loads.",
-                        "Uncheck any row you do not want to print.",
-                        "Ctrl-click lets you pick several separate rows.",
-                        "Shift-click lets you pick a whole group of rows at once.",
-                        "Press Space to check or uncheck the selected rows.",
-                        "Select All checks every row. Clear All unchecks every row. Invert switches checked rows to unchecked and unchecked rows to checked."),
+                        "Enter one train code or a mixed-delimiter list, then run Load Preview.",
+                        "Accepted multi-train examples: JC05262026, JC05272026 or JC05262026/JC05272026.",
+                        "Generate PDF renders checked rows from every loaded train into one combined PDF.",
+                        "Use Print after review when the selected PDF output is ready for the active printer target."),
+                section("Selection Shortcuts",
+                        "Preview rows load checked by default.",
+                        "Ctrl-click adds or removes individual rows from the table selection.",
+                        "Shift-click extends the table selection across a range.",
+                        "Space toggles the printable checkbox for all selected rows.",
+                        "Select All, Clear All, and Invert adjust printable rows without changing the loaded preview."),
                 section("Shortcuts",
-                        "Ctrl+F runs Load Preview when it is enabled.",
-                        "right-click in the Train ID or Output Directory box to copy, paste, cut, or select all when those options are available.")
+                        "Ctrl+F runs Load Preview when Load Preview is enabled.",
+                        "Ctrl+A, Ctrl+C, Ctrl+V, and Ctrl+X use standard text-field editing in train and output fields.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> barcodeGenerator() {
         return List.of(
                 section("Workflow",
-                        "Type or paste the barcode text, choose the barcode type, enter the number of copies, and choose where it should go.",
-                        "For example: type 20554, choose CODE128, set Copies to 1, then click Preview.",
-                        "Generate sends the barcode to the selected printer or saves a file when Print to File is selected."),
-                section("Tools",
-                        "Utility Keyboard gives quick buttons for special keys and symbols.",
-                        "Advanced Settings changes label size, barcode position, barcode thickness, and whether readable text prints below the barcode.")
+                        "Enter barcode data, barcode type, copy count, and printer target before generating.",
+                        "Preview renders the exact ZPL output before the barcode is sent or saved.",
+                        "Generate sends the barcode to the selected printer or writes the ZPL when Print to File is active."),
+                section("Shortcuts And Tools",
+                        "Utility Keyboard provides F-keys, navigation keys, and edit shortcuts for scanner or terminal-style entry.",
+                        "Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X, Ctrl+Z, and Ctrl+Y are available from the utility keyboard palette.",
+                        "Advanced Settings controls label size, barcode origin, module width, ratio, height, and readable text.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> barcodeAdvancedSettings() {
         return List.of(
                 section("Workflow",
-                        "Adjust barcode rendering settings for the active barcode request.",
-                        "Use Done to keep the current settings and return to the generator."),
+                        "Tune barcode rendering for the active barcode request, then use Done to return to the generator.",
+                        "Keep scanner readability in mind when changing module width, ratio, or barcode height."),
                 section("Units",
-                        "Label width, label height, and origins are in printer dots.",
-                        "Module width, ratio, and barcode height affect scanner readability.")
+                        "Label width, label height, and origins use printer dots.",
+                        "Readable text, barcode position, and thickness apply to the generated ZPL preview and print output.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> zplPreview() {
         return List.of(
                 section("Workflow",
-                        "Paste ZPL or open a .zpl file, then render the preview.",
-                        "Use document controls to move through generated multi-document previews.",
-                        "DPMM, width, height, and label index control how Labelary renders the preview."),
+                        "Load ZPL from a file or the editor, then render the preview.",
+                        "Use document controls to move through multi-document preview sets.",
+                        "DPMM, width, height, and label index control Labelary rendering."),
                 section("Shortcuts",
-                        "Enter renders immediately while the ZPL text area is focused.",
-                        "Shift+Enter inserts a new line in the ZPL text area.",
-                        "Render live queues preview updates as the ZPL or render settings change.")
+                        "Enter renders immediately while the ZPL editor is focused.",
+                        "Shift+Enter inserts a line break in the ZPL editor.",
+                        "Render live queues preview updates as ZPL or render settings change.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> queuePrint() {
         return List.of(
                 section("Workflow",
-                        "Paste carrier move or shipment IDs separated by new lines or semicolons.",
+                        "Add carrier move or shipment IDs separated by new lines or semicolons.",
                         "Choose the default type for unprefixed IDs.",
-                        "Use C: or S: prefixes when a queue contains mixed carrier moves and shipments."),
+                        "Use C: and S: prefixes when a queue mixes carrier moves and shipments."),
                 section("Printing",
-                        "Preview Queue validates and prepares the queue before anything prints.",
-                        "Print Queue prints the prepared queue to the currently selected main-window printer target.")
+                        "Preview Queue validates and prepares the queue before print output exists.",
+                        "Print Queue sends the prepared queue to the selected main-window printer target.",
+                        "Interrupted queues can be resumed from the saved checkpoint list.")
         );
     }
 
@@ -109,19 +108,21 @@ public final class GuiHelpTopics {
                         "Advanced Settings opens editable runtime config files."),
                 section("Maintenance",
                         "Clean Old Output Now applies the retention policy immediately.",
-                        "Uninstall / Clean Install Prep launches packaged-install maintenance when available.")
+                        "Uninstall / Clean Install Prep opens packaged-install maintenance when available.",
+                        "Developer mode exposes diagnostic tools without changing the production operator workflow.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> advancedSettings() {
         return List.of(
                 section("Workflow",
-                        "Select an editable config file, change its contents, then Save.",
+                        "Select an editable config file, update its contents, then Save.",
                         "Reload discards the editor contents and reloads the current file from disk.",
                         "Open Config Folder opens the folder containing the selected config file."),
                 section("Scope",
-                        "This editor only changes runtime YAML, CSV, and ZPL config files.",
-                        "Environment secrets stay outside the GUI.")
+                        "The editor is limited to runtime YAML, CSV, and ZPL config files.",
+                        "Environment secrets stay outside the GUI.",
+                        "Use this screen for controlled config edits, not one-off label data.")
         );
     }
 
@@ -130,22 +131,24 @@ public final class GuiHelpTopics {
                 section("Workflow",
                         "Refresh reloads the release catalog.",
                         "Enable experimental / prerelease updates to include prerelease install targets.",
-                        "Select an install target, then Install Selected to launch the configured install action."),
+                        "Select an install target, then use Install Selected to launch the configured install action."),
                 section("Release Page",
                         "Open Release Page opens the selected target release when available.",
-                        "If no target is selected, the latest stable release page is used.")
+                        "If no target is selected, the latest stable release page is used.",
+                        "Installer checksum verification remains part of the guided update path.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> analyzers() {
         return List.of(
                 section("Workflow",
-                        "Choose an analyzer from the list and Refresh to load current data.",
+                        "Choose an analyzer from the list, then use Refresh to load current data.",
                         "Auto refresh repeats the selected analyzer at the chosen interval.",
                         "Some analyzers render as tables and others render as dashboard panels."),
-                section("Usage",
+                section("Diagnostics",
                         "Analyzers are intended for developer and operational diagnostics.",
-                        "The status bar reports the active load state and failures.")
+                        "The status bar reports active load state and failures.",
+                        "Use dashboard sections for operational scan-down and table analyzers for row-level investigation.")
         );
     }
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/GuiHelpTopics.java
@@ -16,44 +16,51 @@ public final class GuiHelpTopics {
     public static List<GuiHelpSupport.HelpSection> mainWindow() {
         return List.of(
                 section("Workflow",
-                        "Choose Carrier Move ID or Shipment ID, enter the ID, then load the preview.",
-                        "Review the generated label math and label selection before printing.",
+                        "Choose Carrier Move ID or Shipment ID, type or paste the number, then click Preview.",
+                        "For example: choose Shipment ID for 8000582489, or choose Carrier Move ID for a carrier move number.",
+                        "Review the labels that appear before printing.",
                         "Use Tools for rail labels, barcode generation, ZPL preview, queue print, resume, and settings."),
                 section("Shortcuts",
                         "Ctrl+F runs Preview when the preview button is enabled.",
-                        "Text fields use terminal-like mouse clipboard behavior where supported."),
+                        "In text boxes, left-click and drag to highlight text.",
+                        "right-click in a text box to copy, paste, cut, or select all when those options are available.",
+                        "You can also use Ctrl+C to copy, Ctrl+V to paste, and Ctrl+A to select all."),
                 section("Printing",
-                        "Confirm Print prints only the selected preview labels.",
-                        "Show Labels opens a generated ZPL preview for the currently selected labels.")
+                        "Confirm Print prints only the labels that are still selected.",
+                        "Show Labels lets you look at the generated labels before sending them to the printer.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> railLabels() {
         return List.of(
                 section("Workflow",
-                        "Enter one or more train codes separated by comma, space, colon, slash, semicolon, or combinations of those characters.",
-                        "Load Preview builds one combined rail label job for all entered trains.",
-                        "Generate PDF creates one PDF containing only rows whose PRINT checkbox is selected."),
+                        "Type one train code, or type several train codes at the same time.",
+                        "For example: 302, 303, 304",
+                        "Other examples that also work: 302 303, 302/303, or 302:303;304",
+                        "Click Load Preview to gather the rail rows for every train you entered.",
+                        "Click Generate PDF to put the selected rail labels into the same PDF."),
                 section("Row Selection",
-                        "All rows are printable by default after preview loads.",
-                        "Ctrl-click adds or removes individual table rows from the current selection.",
-                        "Shift-click selects a row range.",
-                        "Press Space to toggle the PRINT checkbox for selected rows.",
-                        "Select All, Clear All, and Invert update which rail labels will be generated."),
+                        "Every row is checked to print when the preview loads.",
+                        "Uncheck any row you do not want to print.",
+                        "Ctrl-click lets you pick several separate rows.",
+                        "Shift-click lets you pick a whole group of rows at once.",
+                        "Press Space to check or uncheck the selected rows.",
+                        "Select All checks every row. Clear All unchecks every row. Invert switches checked rows to unchecked and unchecked rows to checked."),
                 section("Shortcuts",
-                        "Ctrl+F runs Load Preview when it is enabled.")
+                        "Ctrl+F runs Load Preview when it is enabled.",
+                        "right-click in the Train ID or Output Directory box to copy, paste, cut, or select all when those options are available.")
         );
     }
 
     public static List<GuiHelpSupport.HelpSection> barcodeGenerator() {
         return List.of(
                 section("Workflow",
-                        "Enter barcode data, choose type, copies, and printer target.",
-                        "Preview opens a live ZPL preview for the current barcode request.",
-                        "Generate prints to the selected printer or writes ZPL when Print to File is selected."),
+                        "Type or paste the barcode text, choose the barcode type, enter the number of copies, and choose where it should go.",
+                        "For example: type 20554, choose CODE128, set Copies to 1, then click Preview.",
+                        "Generate sends the barcode to the selected printer or saves a file when Print to File is selected."),
                 section("Tools",
-                        "Utility Keyboard opens scanner-friendly symbol entry.",
-                        "Advanced Settings adjusts orientation, dimensions, origin, module width, ratio, and human-readable text.")
+                        "Utility Keyboard gives quick buttons for special keys and symbols.",
+                        "Advanced Settings changes label size, barcode position, barcode thickness, and whether readable text prints below the barcode.")
         );
     }
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/LabelGuiFrame.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/LabelGuiFrame.java
@@ -134,7 +134,7 @@ public final class LabelGuiFrame extends JFrame {
         setLayout(new BorderLayout(8, 8));
 
         JPanel topContainer = new JPanel(new BorderLayout());
-        topContainer.add(buildToolBar(), BorderLayout.NORTH);
+        topContainer.add(buildToolBarRow(), BorderLayout.NORTH);
         topContainer.add(buildTopPanel(), BorderLayout.SOUTH);
         add(topContainer, BorderLayout.NORTH);
         add(buildCenterPanel(), BorderLayout.CENTER);
@@ -197,6 +197,15 @@ public final class LabelGuiFrame extends JFrame {
 
     private JComponent buildToolBar() {
         return toolMenuSupport.buildToolBar(toolsButton, buildToolMenuActions(), this::developerModeEnabled);
+    }
+
+    private JComponent buildToolBarRow() {
+        JPanel row = new JPanel(new BorderLayout());
+        row.add(buildToolBar(), BorderLayout.WEST);
+        JPanel helpPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 2));
+        helpPanel.add(GuiHelpSupport.createHelpButton(this, "WMS Pallet Tag System", GuiHelpTopics.mainWindow()));
+        row.add(helpPanel, BorderLayout.EAST);
+        return row;
     }
 
     private JComponent buildTopPanel() {

--- a/gui/src/main/java/com/tbg/wms/cli/gui/LabelGuiFrame.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/LabelGuiFrame.java
@@ -1007,7 +1007,7 @@ public final class LabelGuiFrame extends JFrame {
             return message;
         }
         String exceptionType = throwable.getClass().getSimpleName();
-        if (message == null || message.isBlank()) {
+        if (message.isBlank()) {
             return exceptionType;
         }
         return exceptionType + ": " + message;

--- a/gui/src/main/java/com/tbg/wms/cli/gui/MainSettingsDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/MainSettingsDialog.java
@@ -124,6 +124,9 @@ final class MainSettingsDialog extends JDialog {
         saveButton.addActionListener(e -> saveSettings(outputDirField, retentionDaysField));
         cancelButton.addActionListener(e -> dispose());
 
+        JPanel helpHeader = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpHeader.add(GuiHelpSupport.createHelpButton(this, "Settings", GuiHelpTopics.settings()));
+        add(helpHeader, BorderLayout.NORTH);
         add(content, BorderLayout.CENTER);
         add(buttonRow, BorderLayout.SOUTH);
         pack();

--- a/gui/src/main/java/com/tbg/wms/cli/gui/QueueResumeDialogSupport.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/QueueResumeDialogSupport.java
@@ -45,7 +45,12 @@ final class QueueResumeDialogSupport {
         JPanel controls = new JPanel(new FlowLayout(FlowLayout.LEFT));
         controls.add(new JLabel("Default Type (fallback):"));
         controls.add(defaultType);
-        top.add(controls, BorderLayout.NORTH);
+        JPanel header = new JPanel(new BorderLayout());
+        header.add(controls, BorderLayout.WEST);
+        JPanel helpPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 0));
+        helpPanel.add(GuiHelpSupport.createHelpButton(dialog, "Queue Print", GuiHelpTopics.queuePrint()));
+        header.add(helpPanel, BorderLayout.EAST);
+        top.add(header, BorderLayout.NORTH);
         top.add(new JScrollPane(inputArea), BorderLayout.CENTER);
         top.add(hint, BorderLayout.SOUTH);
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/UpdateManagerDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/UpdateManagerDialog.java
@@ -98,8 +98,14 @@ final class UpdateManagerDialog extends JDialog {
         buttons.add(installButton);
         buttons.add(closeButton);
 
+        JPanel header = new JPanel(new BorderLayout());
+        header.add(dialogStatusLabel, BorderLayout.CENTER);
+        JPanel helpPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpPanel.add(GuiHelpSupport.createHelpButton(this, "Update Manager", GuiHelpTopics.updates()));
+        header.add(helpPanel, BorderLayout.EAST);
+
         add(content, BorderLayout.CENTER);
-        add(dialogStatusLabel, BorderLayout.NORTH);
+        add(header, BorderLayout.NORTH);
         add(buttons, BorderLayout.SOUTH);
 
         experimentalCheckBox.addActionListener(e -> reloadSnapshot());

--- a/gui/src/main/java/com/tbg/wms/cli/gui/ZplPreviewToolDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/ZplPreviewToolDialog.java
@@ -14,6 +14,7 @@ import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.Objects;
  * transport so the preview remains operator-friendly without overrunning the external render API.</p>
  */
 final class ZplPreviewToolDialog extends JDialog {
+    @Serial
     private static final long serialVersionUID = 1L;
     private static final int LIVE_RENDER_DEBOUNCE_MS = 350;
     private static final int MIN_RENDER_INTERVAL_MS = 1000;
@@ -361,7 +363,8 @@ final class ZplPreviewToolDialog extends JDialog {
         }
 
         int generation = ++renderGeneration;
-        int dpmm = (Integer) dpmmCombo.getSelectedItem();
+        Integer selectedDpmm = (Integer) dpmmCombo.getSelectedItem();
+        int dpmm = selectedDpmm == null ? 8 : selectedDpmm;
         double width = ((Number) widthSpinner.getValue()).doubleValue();
         double height = ((Number) heightSpinner.getValue()).doubleValue();
         int index = ((Number) indexSpinner.getValue()).intValue();

--- a/gui/src/main/java/com/tbg/wms/cli/gui/ZplPreviewToolDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/ZplPreviewToolDialog.java
@@ -83,6 +83,11 @@ final class ZplPreviewToolDialog extends JDialog {
         topBar.add(new JLabel("Label #"));
         topBar.add(indexSpinner);
         topBar.add(liveCheck);
+        JPanel topHeader = new JPanel(new BorderLayout());
+        topHeader.add(topBar, BorderLayout.WEST);
+        JPanel helpPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpPanel.add(GuiHelpSupport.createHelpButton(this, "ZPL Preview Tool", GuiHelpTopics.zplPreview()));
+        topHeader.add(helpPanel, BorderLayout.EAST);
 
         JScrollPane textScroll = new JScrollPane(zplTextArea);
         JScrollPane previewScroll = new JScrollPane(previewLabel);
@@ -93,7 +98,7 @@ final class ZplPreviewToolDialog extends JDialog {
         footer.add(statusLabel, BorderLayout.CENTER);
         footer.add(new JLabel("Rendered via Labelary preview API. Network access required."), BorderLayout.EAST);
 
-        add(topBar, BorderLayout.NORTH);
+        add(topHeader, BorderLayout.NORTH);
         add(splitPane, BorderLayout.CENTER);
         add(footer, BorderLayout.SOUTH);
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/analyzers/AnalyzerDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/analyzers/AnalyzerDialog.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Executors;
 
 import com.tbg.wms.cli.gui.analyzers.dashboard.AnalyzerDashboardPanel;
 import com.tbg.wms.cli.gui.analyzers.dashboard.AnalyzerDashboardSnapshot;
+import com.tbg.wms.cli.gui.GuiHelpSupport;
+import com.tbg.wms.cli.gui.GuiHelpTopics;
 
 @SuppressWarnings("serial")
 public final class AnalyzerDialog extends JDialog {
@@ -141,9 +143,14 @@ public final class AnalyzerDialog extends JDialog {
         toolbar.add(autoRefreshCheckBox);
         toolbar.add(intervalCombo);
         toolbar.add(lastUpdatedLabel);
+        JPanel header = new JPanel(new BorderLayout());
+        header.add(toolbar, BorderLayout.WEST);
+        JPanel helpPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 4));
+        helpPanel.add(GuiHelpSupport.createHelpButton(this, "Analyzers", GuiHelpTopics.analyzers()));
+        header.add(helpPanel, BorderLayout.EAST);
         contentPanel.add(tableScrollPane, "table");
         contentPanel.add(dashboardPanel, "dashboard");
-        add(toolbar, BorderLayout.NORTH);
+        add(header, BorderLayout.NORTH);
         add(contentPanel, BorderLayout.CENTER);
         add(statusLabel, BorderLayout.SOUTH);
     }

--- a/gui/src/main/java/com/tbg/wms/cli/gui/analyzers/unpicked/UnpickedPartialsDataProvider.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/analyzers/unpicked/UnpickedPartialsDataProvider.java
@@ -9,13 +9,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
-public final class UnpickedPartialsDataProvider implements AnalyzerDataProvider<UnpickedPartialsRow> {
+final class UnpickedPartialsDataProvider implements AnalyzerDataProvider<UnpickedPartialsRow> {
 
     private final UnpickedPartialsQueryService queryService;
     private final UnpickedPartialsRuleClassifier classifier;
     private final Clock clock;
 
-    public UnpickedPartialsDataProvider(
+    UnpickedPartialsDataProvider(
             UnpickedPartialsQueryService queryService,
             UnpickedPartialsRuleClassifier classifier,
             Clock clock

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupport.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupport.java
@@ -6,32 +6,36 @@ package com.tbg.wms.cli.gui.rail;
 import com.tbg.wms.cli.gui.GuiExceptionMessageSupport;
 import com.tbg.wms.cli.gui.GuiPrinterTargetSupport;
 import com.tbg.wms.cli.gui.LabelWorkflowService;
+import com.tbg.wms.core.rail.RailCarCard;
+import com.tbg.wms.core.rail.RailTrainInputParser;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * Execution and messaging helpers for the rail dialog shell.
  */
 final class RailDialogExecutionSupport {
+    private final RailTrainInputParser trainInputParser = new RailTrainInputParser();
 
     PreviewRequest preparePreviewRequest(String trainId) {
-        String normalized = trainId == null ? "" : trainId.trim();
-        if (normalized.isEmpty()) {
-            throw new IllegalArgumentException("Train ID is required.");
-        }
-        return new PreviewRequest(normalized);
+        return new PreviewRequest(trainInputParser.parse(trainId));
     }
 
     GenerationRequest prepareGenerationRequest(
             RailWorkflowService.PreparedRailJob preparedJob,
+            List<RailCarCard> selectedCards,
             String outputDirText,
             LabelWorkflowService.PrinterOption selectedPrinter,
             boolean forcePrint,
             boolean printNowSelected
     ) {
         Objects.requireNonNull(preparedJob, "preparedJob cannot be null");
+        if (selectedCards == null || selectedCards.isEmpty()) {
+            throw new IllegalArgumentException("Select at least one rail row to generate.");
+        }
         boolean printToFile = GuiPrinterTargetSupport.isPrintToFile(selectedPrinter);
         boolean shouldPrint = !printToFile && (forcePrint || printNowSelected);
         Path outputDir = outputDirText == null || outputDirText.trim().isEmpty()
@@ -40,7 +44,7 @@ final class RailDialogExecutionSupport {
         String printerId = shouldPrint && selectedPrinter != null
                 ? selectedPrinter.getId()
                 : GuiPrinterTargetSupport.FILE_PRINTER_ID;
-        return new GenerationRequest(outputDir, printerId, shouldPrint);
+        return new GenerationRequest(List.copyOf(selectedCards), outputDir, printerId, shouldPrint);
     }
 
     String previewReadyMessage() {
@@ -63,10 +67,11 @@ final class RailDialogExecutionSupport {
         return GuiExceptionMessageSupport.rootMessage(throwable);
     }
 
-    record PreviewRequest(String trainId) {
+    record PreviewRequest(List<String> trainIds) {
     }
 
     record GenerationRequest(
+            List<RailCarCard> selectedCards,
             Path outputDirectory,
             String printerId,
             boolean shouldPrint

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java
@@ -4,6 +4,8 @@
 package com.tbg.wms.cli.gui.rail;
 
 import com.tbg.wms.cli.gui.GuiExceptionMessageSupport;
+import com.tbg.wms.cli.gui.GuiHelpSupport;
+import com.tbg.wms.cli.gui.GuiHelpTopics;
 import com.tbg.wms.cli.gui.GuiPrinterTargetSupport;
 import com.tbg.wms.cli.gui.LabelWorkflowService;
 import com.tbg.wms.cli.gui.TextFieldClipboardController;
@@ -102,6 +104,11 @@ public final class RailLabelsDialog extends JDialog {
         panel.add(generatePdfButton, gbc);
         gbc.gridx = 4;
         panel.add(printButton, gbc);
+
+        gbc.gridx = 5;
+        gbc.anchor = GridBagConstraints.NORTHEAST;
+        panel.add(GuiHelpSupport.createHelpButton(this, "Rail Labels", GuiHelpTopics.railLabels()), gbc);
+        gbc.anchor = GridBagConstraints.WEST;
 
         gbc.gridx = 0;
         gbc.gridy = 1;

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailLabelsDialog.java
@@ -12,7 +12,6 @@ import com.tbg.wms.core.AppConfig;
 import com.tbg.wms.core.rail.RailCarCard;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.io.Serial;
 import java.nio.file.Path;
@@ -35,14 +34,11 @@ public final class RailLabelsDialog extends JDialog {
     private final JButton loadButton = new JButton("Load Preview");
     private final JButton generatePdfButton = new JButton("Generate PDF");
     private final JButton printButton = new JButton("Print");
+    private final JButton selectAllButton = new JButton("Select All");
+    private final JButton clearAllButton = new JButton("Clear All");
+    private final JButton invertSelectionButton = new JButton("Invert");
 
-    private final DefaultTableModel tableModel = new DefaultTableModel(
-            new Object[]{"SEQ", "VEHICLE", "CAN", "DOM", "KEV", "LOAD_NBR"}, 0) {
-        @Override
-        public boolean isCellEditable(int row, int column) {
-            return false;
-        }
-    };
+    private final RailPrintableCardTableModel tableModel = new RailPrintableCardTableModel();
     private final JTable previewTable = new JTable(tableModel);
     private final JTextArea cardPreviewArea = new JTextArea();
     private final JTextArea diagnosticsArea = new JTextArea();
@@ -76,6 +72,7 @@ public final class RailLabelsDialog extends JDialog {
         add(buildBottomPanel(), BorderLayout.SOUTH);
         clipboardController.install(trainIdField, outputDirField);
         wireActions();
+        bindTableSelectionShortcuts();
         WorkflowShortcutBinder.bindPreviewShortcut(getRootPane(), loadButton, "loadRailPreview");
         applyUiState(uiStateSupport.initial());
         loadPrintersAsync();
@@ -147,15 +144,22 @@ public final class RailLabelsDialog extends JDialog {
     }
 
     private JComponent buildCenterPanel() {
-        previewTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        previewTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         previewTable.getSelectionModel().addListSelectionListener(e -> updateCardPreviewFromSelection());
         JScrollPane tableScroll = new JScrollPane(previewTable);
-        tableScroll.setBorder(BorderFactory.createTitledBorder("Railcar Preview Table"));
+        JPanel tablePanel = new JPanel(new BorderLayout(4, 4));
+        tablePanel.setBorder(BorderFactory.createTitledBorder("Railcar Preview Table"));
+        tablePanel.add(tableScroll, BorderLayout.CENTER);
+        JPanel selectionControls = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
+        selectionControls.add(selectAllButton);
+        selectionControls.add(clearAllButton);
+        selectionControls.add(invertSelectionButton);
+        tablePanel.add(selectionControls, BorderLayout.SOUTH);
 
         JScrollPane cardScroll = new JScrollPane(cardPreviewArea);
         cardScroll.setBorder(BorderFactory.createTitledBorder("Railcar Card Preview"));
 
-        JSplitPane horizontal = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableScroll, cardScroll);
+        JSplitPane horizontal = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tablePanel, cardScroll);
         horizontal.setDividerLocation(560);
 
         JScrollPane diagnosticsScroll = new JScrollPane(diagnosticsArea);
@@ -181,6 +185,24 @@ public final class RailLabelsDialog extends JDialog {
         generatePdfButton.addActionListener(e -> generate(false));
         printButton.addActionListener(e -> generate(true));
         printerCombo.addActionListener(e -> syncPrintTargetUi());
+        selectAllButton.addActionListener(e -> tableModel.setAllPrintable());
+        clearAllButton.addActionListener(e -> tableModel.clearAllPrintable());
+        invertSelectionButton.addActionListener(e -> tableModel.invertPrintable());
+    }
+
+    private void bindTableSelectionShortcuts() {
+        previewTable.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke("SPACE"), "togglePrintableRows");
+        previewTable.getActionMap().put("togglePrintableRows", new AbstractAction() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                int[] selectedRows = previewTable.getSelectedRows();
+                int[] modelRows = new int[selectedRows.length];
+                for (int i = 0; i < selectedRows.length; i++) {
+                    modelRows[i] = previewTable.convertRowIndexToModel(selectedRows[i]);
+                }
+                tableModel.togglePrintableRows(modelRows);
+            }
+        });
     }
 
     private void browseOutputDirectory() {
@@ -209,7 +231,7 @@ public final class RailLabelsDialog extends JDialog {
         SwingWorker<RailWorkflowService.PreparedRailJob, Void> worker = new SwingWorker<>() {
             @Override
             protected RailWorkflowService.PreparedRailJob doInBackground() throws Exception {
-                return service.prepareRailJob(request.trainId());
+                return service.prepareRailJob(request.trainIds());
             }
 
             @Override
@@ -239,19 +261,26 @@ public final class RailLabelsDialog extends JDialog {
             return;
         }
 
-        RailDialogExecutionSupport.GenerationRequest request = executionSupport.prepareGenerationRequest(
-                preparedJob,
-                outputDirField.getText(),
-                (LabelWorkflowService.PrinterOption) printerCombo.getSelectedItem(),
-                forcePrint,
-                printNowCheck.isSelected()
-        );
+        RailDialogExecutionSupport.GenerationRequest request;
+        try {
+            request = executionSupport.prepareGenerationRequest(
+                    preparedJob,
+                    tableModel.selectedCards(),
+                    outputDirField.getText(),
+                    (LabelWorkflowService.PrinterOption) printerCombo.getSelectedItem(),
+                    forcePrint,
+                    printNowCheck.isSelected()
+            );
+        } catch (IllegalArgumentException ex) {
+            showError(ex.getMessage());
+            return;
+        }
         applyUiState(uiStateSupport.generationBusy(executionSupport.generationBusyMessage(request.shouldPrint())));
 
         SwingWorker<RailWorkflowService.GenerationResult, Void> worker = new SwingWorker<>() {
             @Override
             protected RailWorkflowService.GenerationResult doInBackground() throws Exception {
-                return service.generatePdf(preparedJob, request.outputDirectory(), request.printerId());
+                return service.generatePdf(preparedJob, request.selectedCards(), request.outputDirectory(), request.printerId());
             }
 
             @Override
@@ -271,17 +300,7 @@ public final class RailLabelsDialog extends JDialog {
     }
 
     private void renderTable(List<RailCarCard> cards) {
-        tableModel.setRowCount(0);
-        for (RailCarCard card : cards) {
-            tableModel.addRow(new Object[]{
-                    card.getSequence(),
-                    card.getVehicleId(),
-                    card.getCanPallets(),
-                    card.getDomPallets(),
-                    card.getKevPallets(),
-                    card.getLoadNumbers()
-            });
-        }
+        tableModel.setCards(cards);
     }
 
     private void updateCardPreviewFromSelection() {
@@ -290,17 +309,22 @@ public final class RailLabelsDialog extends JDialog {
             return;
         }
         int index = previewTable.getSelectedRow();
-        if (index < 0 || index >= preparedJob.getCards().size()) {
+        if (index < 0) {
             cardPreviewArea.setText("");
             return;
         }
-        cardPreviewArea.setText(service.buildCardPreviewText(preparedJob.getCards().get(index)));
+        int modelIndex = previewTable.convertRowIndexToModel(index);
+        if (modelIndex < 0 || modelIndex >= tableModel.getRowCount()) {
+            cardPreviewArea.setText("");
+            return;
+        }
+        cardPreviewArea.setText(service.buildCardPreviewText(tableModel.cardAt(modelIndex)));
         cardPreviewArea.setCaretPosition(0);
     }
 
     private void clearPreview() {
         preparedJob = null;
-        tableModel.setRowCount(0);
+        tableModel.setCards(List.of());
         cardPreviewArea.setText("");
         diagnosticsArea.setText("");
     }

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModel.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModel.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.cli.gui.rail;
+
+import com.tbg.wms.core.rail.RailCarCard;
+
+import javax.swing.table.AbstractTableModel;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Table model for rail preview rows and their explicit print-inclusion state.
+ */
+final class RailPrintableCardTableModel extends AbstractTableModel {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private static final String[] COLUMNS = {
+            "PRINT", "TRAIN", "SEQ", "VEHICLE", "CAN", "DOM", "KEV", "LOAD_NBR"
+    };
+
+    private final transient List<RailCarCard> cards = new ArrayList<>();
+    private final transient List<Boolean> printable = new ArrayList<>();
+
+    void setCards(List<RailCarCard> newCards) {
+        cards.clear();
+        printable.clear();
+        if (newCards != null) {
+            cards.addAll(newCards);
+            for (int i = 0; i < newCards.size(); i++) {
+                printable.add(Boolean.TRUE);
+            }
+        }
+        fireTableDataChanged();
+    }
+
+    RailCarCard cardAt(int modelRow) {
+        return cards.get(modelRow);
+    }
+
+    List<RailCarCard> selectedCards() {
+        List<RailCarCard> selected = new ArrayList<>();
+        for (int i = 0; i < cards.size(); i++) {
+            if (Boolean.TRUE.equals(printable.get(i))) {
+                selected.add(cards.get(i));
+            }
+        }
+        return List.copyOf(selected);
+    }
+
+    int selectedCount() {
+        int count = 0;
+        for (Boolean value : printable) {
+            if (Boolean.TRUE.equals(value)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    int totalCount() {
+        return cards.size();
+    }
+
+    void setAllPrintable() {
+        setPrintableRange(true);
+    }
+
+    void clearAllPrintable() {
+        setPrintableRange(false);
+    }
+
+    void invertPrintable() {
+        for (int i = 0; i < printable.size(); i++) {
+            printable.set(i, !Boolean.TRUE.equals(printable.get(i)));
+        }
+        firePrintableColumnUpdated();
+    }
+
+    void togglePrintableRows(int[] modelRows) {
+        if (modelRows == null) {
+            return;
+        }
+        for (int modelRow : modelRows) {
+            if (modelRow >= 0 && modelRow < printable.size()) {
+                printable.set(modelRow, !Boolean.TRUE.equals(printable.get(modelRow)));
+            }
+        }
+        firePrintableColumnUpdated();
+    }
+
+    private void setPrintableRange(boolean value) {
+        for (int i = 0; i < printable.size(); i++) {
+            printable.set(i, value);
+        }
+        firePrintableColumnUpdated();
+    }
+
+    private void firePrintableColumnUpdated() {
+        if (!printable.isEmpty()) {
+            fireTableRowsUpdated(0, printable.size() - 1);
+        }
+    }
+
+    @Override
+    public int getRowCount() {
+        return cards.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMNS.length;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return COLUMNS[column];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        return columnIndex == 0 ? Boolean.class : Object.class;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return columnIndex == 0;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        RailCarCard card = cards.get(rowIndex);
+        return switch (columnIndex) {
+            case 0 -> printable.get(rowIndex);
+            case 1 -> card.getTrainId();
+            case 2 -> card.getSequence();
+            case 3 -> card.getVehicleId();
+            case 4 -> card.getCanPallets();
+            case 5 -> card.getDomPallets();
+            case 6 -> card.getKevPallets();
+            case 7 -> card.getLoadNumbers();
+            default -> throw new IllegalArgumentException("Column index out of range: " + columnIndex);
+        };
+    }
+
+    @Override
+    public void setValueAt(Object value, int rowIndex, int columnIndex) {
+        if (columnIndex == 0 && rowIndex >= 0 && rowIndex < printable.size()) {
+            printable.set(rowIndex, Boolean.TRUE.equals(value));
+            fireTableCellUpdated(rowIndex, columnIndex);
+        }
+    }
+}

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java
@@ -13,6 +13,7 @@ import com.tbg.wms.core.rail.RailCarCard;
 import com.tbg.wms.core.rail.RailCardRenderer;
 import com.tbg.wms.core.rail.RailDbRepository;
 import com.tbg.wms.core.rail.RailPrintService;
+import com.tbg.wms.core.rail.RailTrainInputParser;
 import com.tbg.wms.db.DbConnectionPool;
 import com.tbg.wms.db.OracleDbQueryRepository;
 import com.tbg.wms.db.WmsRailDbRepository;
@@ -45,11 +46,21 @@ public final class RailWorkflowService {
      * @return prepared immutable preview payload
      */
     public PreparedRailJob prepareRailJob(String trainId) throws Exception {
+        return prepareRailJob(new RailTrainInputParser().parse(trainId));
+    }
+
+    /**
+     * Loads and prepares railcard preview data from WMS for one or more trains.
+     *
+     * @param trainIds normalized train identifiers entered by the operator
+     * @return prepared immutable preview payload
+     */
+    public PreparedRailJob prepareRailJob(List<String> trainIds) throws Exception {
         try (DbConnectionPool pool = new DbConnectionPool(config)) {
             RailDbRepository repository = new WmsRailDbRepository(new OracleDbQueryRepository(pool.getDataSource()));
             com.tbg.wms.core.rail.RailWorkflowService workflow =
                     new com.tbg.wms.core.rail.RailWorkflowService(repository);
-            com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowResult result = workflow.prepare(trainId);
+            com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowBatchResult result = workflow.prepareAll(trainIds);
             return new PreparedRailJob(result);
         }
     }
@@ -80,17 +91,34 @@ public final class RailWorkflowService {
      * @return generation result details
      */
     public GenerationResult generatePdf(PreparedRailJob job, Path outputDir, String printerId) throws Exception {
+        return generatePdf(job, job.getCards(), outputDir, printerId);
+    }
+
+    /**
+     * Renders selected cards to PDF and optionally sends the result to printer.
+     *
+     * @param job           prepared job produced by {@link #prepareRailJob(List)}
+     * @param selectedCards selected cards to render
+     * @param outputDir     optional output directory (null for timestamped default)
+     * @param printerId     printer target ID, `SYSTEM_DEFAULT`, or null/blank/FILE to skip printing
+     * @return generation result details
+     */
+    public GenerationResult generatePdf(PreparedRailJob job,
+                                        List<RailCarCard> selectedCards,
+                                        Path outputDir,
+                                        String printerId) throws Exception {
         Objects.requireNonNull(job, "job cannot be null");
+        Objects.requireNonNull(selectedCards, "selectedCards cannot be null");
         Path targetDir = outputDir == null
-                ? Path.of("out", "rail-gui-" + job.result.getTrainId() + "-" + TS.format(LocalDateTime.now()))
+                ? Path.of("out", "rail-gui-" + job.fileNameToken() + "-" + TS.format(LocalDateTime.now()))
                 : outputDir;
         Files.createDirectories(targetDir);
-        Path pdfPath = targetDir.resolve("rail-cards-" + job.result.getTrainId() + ".pdf");
+        Path pdfPath = targetDir.resolve("rail-cards-" + job.fileNameToken() + ".pdf");
         new RailCardRenderer(
                 (float) config.railLabelCenterGapInches(),
                 (float) config.railLabelOffsetXInches(),
                 (float) config.railLabelOffsetYInches()
-        ).renderPdf(job.result.getCards(), pdfPath);
+        ).renderPdf(selectedCards, pdfPath);
         String targetPrinterId = printerId == null ? "" : printerId.trim();
         if (GuiPrinterTargetSupport.SYSTEM_DEFAULT_PRINTER_ID.equals(targetPrinterId)) {
             new RailPrintService().print(pdfPath);
@@ -145,30 +173,79 @@ public final class RailWorkflowService {
         StringBuilder sb = new StringBuilder();
         sb.append("Rail Diagnostics").append('\n');
         sb.append("================").append('\n');
-        sb.append("Train ID: ").append(job.result.getTrainId()).append('\n');
-        sb.append("WMS rows: ").append(job.result.getRawRows().size()).append('\n');
-        sb.append("Railcars: ").append(job.result.getCards().size()).append('\n');
-        sb.append("Resolved footprints: ").append(job.result.getResolvedFootprints().size()).append('\n');
-        sb.append("Unresolved short codes: ").append(job.result.getUnresolvedShortCodes().size()).append('\n');
-        if (!job.result.getUnresolvedShortCodes().isEmpty()) {
-            sb.append("Unresolved: ").append(String.join(", ", job.result.getUnresolvedShortCodes())).append('\n');
+        sb.append("Train IDs: ").append(String.join(", ", job.getTrainIds())).append('\n');
+        sb.append("WMS rows: ").append(job.getRawRowsCount()).append('\n');
+        sb.append("Railcars: ").append(job.getCards().size()).append('\n');
+        sb.append("Resolved footprints: ").append(job.getResolvedFootprintsCount()).append('\n');
+        sb.append("Unresolved short codes: ").append(job.getUnresolvedShortCodes().size()).append('\n');
+        if (!job.getUnresolvedShortCodes().isEmpty()) {
+            sb.append("Unresolved: ").append(String.join(", ", job.getUnresolvedShortCodes())).append('\n');
         }
         return sb.toString();
     }
 
     public static final class PreparedRailJob {
         private final com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowResult result;
+        private final com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowBatchResult batchResult;
 
         private PreparedRailJob(com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowResult result) {
             this.result = result;
+            this.batchResult = null;
+        }
+
+        private PreparedRailJob(com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowBatchResult batchResult) {
+            this.result = null;
+            this.batchResult = batchResult;
         }
 
         public String getTrainId() {
-            return result.getTrainId();
+            return getTrainIds().isEmpty() ? "" : getTrainIds().get(0);
+        }
+
+        public List<String> getTrainIds() {
+            if (batchResult != null) {
+                return batchResult.getTrainIds();
+            }
+            return List.of(result.getTrainId());
         }
 
         public List<RailCarCard> getCards() {
+            if (batchResult != null) {
+                return batchResult.getCards();
+            }
             return result.getCards();
+        }
+
+        private int getRawRowsCount() {
+            if (batchResult != null) {
+                return batchResult.getRawRows().size();
+            }
+            return result.getRawRows().size();
+        }
+
+        private int getResolvedFootprintsCount() {
+            if (batchResult != null) {
+                return batchResult.getResolvedFootprints().size();
+            }
+            return result.getResolvedFootprints().size();
+        }
+
+        private java.util.Set<String> getUnresolvedShortCodes() {
+            if (batchResult != null) {
+                return batchResult.getUnresolvedShortCodes();
+            }
+            return result.getUnresolvedShortCodes();
+        }
+
+        private String fileNameToken() {
+            List<String> trainIds = getTrainIds();
+            if (trainIds.isEmpty()) {
+                return "rail";
+            }
+            if (trainIds.size() == 1) {
+                return trainIds.get(0);
+            }
+            return trainIds.get(0) + "-plus-" + (trainIds.size() - 1);
         }
     }
 

--- a/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java
+++ b/gui/src/main/java/com/tbg/wms/cli/gui/rail/RailWorkflowService.java
@@ -189,13 +189,13 @@ public final class RailWorkflowService {
         private final com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowBatchResult batchResult;
 
         private PreparedRailJob(com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowResult result) {
-            this.result = result;
+            this.result = Objects.requireNonNull(result, "result cannot be null");
             this.batchResult = null;
         }
 
         private PreparedRailJob(com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowBatchResult batchResult) {
             this.result = null;
-            this.batchResult = batchResult;
+            this.batchResult = Objects.requireNonNull(batchResult, "batchResult cannot be null");
         }
 
         public String getTrainId() {
@@ -206,35 +206,39 @@ public final class RailWorkflowService {
             if (batchResult != null) {
                 return batchResult.getTrainIds();
             }
-            return List.of(result.getTrainId());
+            return List.of(singleResult().getTrainId());
         }
 
         public List<RailCarCard> getCards() {
             if (batchResult != null) {
                 return batchResult.getCards();
             }
-            return result.getCards();
+            return singleResult().getCards();
         }
 
         private int getRawRowsCount() {
             if (batchResult != null) {
                 return batchResult.getRawRows().size();
             }
-            return result.getRawRows().size();
+            return singleResult().getRawRows().size();
         }
 
         private int getResolvedFootprintsCount() {
             if (batchResult != null) {
                 return batchResult.getResolvedFootprints().size();
             }
-            return result.getResolvedFootprints().size();
+            return singleResult().getResolvedFootprints().size();
         }
 
         private java.util.Set<String> getUnresolvedShortCodes() {
             if (batchResult != null) {
                 return batchResult.getUnresolvedShortCodes();
             }
-            return result.getUnresolvedShortCodes();
+            return singleResult().getUnresolvedShortCodes();
+        }
+
+        private com.tbg.wms.core.rail.RailWorkflowService.RailWorkflowResult singleResult() {
+            return Objects.requireNonNull(result, "result cannot be null");
         }
 
         private String fileNameToken() {

--- a/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
@@ -1,0 +1,40 @@
+package com.tbg.wms.cli.gui;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JButton;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GuiHelpSupportTest {
+
+    @Test
+    void formatHelpTextIncludesSectionsAndShortcuts() {
+        String helpText = GuiHelpSupport.formatHelpText(List.of(
+                new GuiHelpSupport.HelpSection("Shortcuts", List.of("Ctrl+F loads the preview.", "Space toggles selected rows.")),
+                new GuiHelpSupport.HelpSection("Workflow", List.of("Select the rows that should print."))
+        ));
+
+        assertTrue(helpText.contains("Shortcuts"));
+        assertTrue(helpText.contains("- Ctrl+F loads the preview."));
+        assertTrue(helpText.contains("- Space toggles selected rows."));
+        assertTrue(helpText.contains("Workflow"));
+    }
+
+    @Test
+    void createHelpButtonUsesConsistentLabelTooltipAndAction() {
+        JButton button = GuiHelpSupport.createHelpButton(null, "Rail Labels", List.of(
+                new GuiHelpSupport.HelpSection("Rows", List.of("Ctrl-click selects additional rows."))
+        ));
+
+        assertEquals("Help", button.getText());
+        assertEquals("Show help for Rail Labels", button.getToolTipText());
+        assertFalse(button.isFocusable());
+        ActionListener[] listeners = button.getActionListeners();
+        assertEquals(1, listeners.length);
+    }
+}

--- a/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
@@ -53,9 +53,9 @@ class GuiHelpSupportTest {
     void railHelpExplainsMultipleTrainInputWithConcreteExamples() {
         String helpText = GuiHelpSupport.formatHelpText(GuiHelpTopics.railLabels());
 
-        assertTrue(helpText.contains("302, 303, 304"));
-        assertTrue(helpText.contains("302/303"));
-        assertTrue(helpText.contains("302:303;304"));
+        assertTrue(helpText.contains("JC05262026"));
+        assertTrue(helpText.contains("JC05262026, JC05272026"));
+        assertTrue(helpText.contains("JC05262026/JC05272026"));
         assertTrue(helpText.contains("same PDF"));
         assertTrue(helpText.contains("uncheck"));
         assertNotNull(helpText);

--- a/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GuiHelpSupportTest {
@@ -36,5 +37,27 @@ class GuiHelpSupportTest {
         assertFalse(button.isFocusable());
         ActionListener[] listeners = button.getActionListeners();
         assertEquals(1, listeners.length);
+    }
+
+    @Test
+    void mainWindowHelpUsesPlainLanguageExamplesAndMouseCopyPasteWording() {
+        String helpText = GuiHelpSupport.formatHelpText(GuiHelpTopics.mainWindow());
+
+        assertTrue(helpText.contains("For example:"));
+        assertTrue(helpText.contains("left-click and drag"));
+        assertTrue(helpText.contains("right-click"));
+        assertFalse(helpText.toLowerCase().contains("terminal-like"));
+    }
+
+    @Test
+    void railHelpExplainsMultipleTrainInputWithConcreteExamples() {
+        String helpText = GuiHelpSupport.formatHelpText(GuiHelpTopics.railLabels());
+
+        assertTrue(helpText.contains("302, 303, 304"));
+        assertTrue(helpText.contains("302/303"));
+        assertTrue(helpText.contains("302:303;304"));
+        assertTrue(helpText.contains("same PDF"));
+        assertTrue(helpText.contains("uncheck"));
+        assertNotNull(helpText);
     }
 }

--- a/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/GuiHelpSupportTest.java
@@ -40,24 +40,56 @@ class GuiHelpSupportTest {
     }
 
     @Test
-    void mainWindowHelpUsesPlainLanguageExamplesAndMouseCopyPasteWording() {
+    void mainWindowHelpPrioritizesOperatorWorkflowAndShortcuts() {
         String helpText = GuiHelpSupport.formatHelpText(GuiHelpTopics.mainWindow());
 
-        assertTrue(helpText.contains("For example:"));
-        assertTrue(helpText.contains("left-click and drag"));
-        assertTrue(helpText.contains("right-click"));
+        assertTrue(helpText.contains("Ctrl+F"));
+        assertTrue(helpText.contains("Ctrl+C"));
+        assertTrue(helpText.contains("Ctrl+V"));
+        assertTrue(helpText.contains("Ctrl+A"));
+        assertTrue(helpText.contains("selected labels"));
+        assertFalse(helpText.contains("left-click and drag"));
+        assertFalse(helpText.toLowerCase().contains("right-click"));
         assertFalse(helpText.toLowerCase().contains("terminal-like"));
     }
 
     @Test
-    void railHelpExplainsMultipleTrainInputWithConcreteExamples() {
+    void railHelpHighlightsSelectionShortcutsAndCombinedPdfBehavior() {
         String helpText = GuiHelpSupport.formatHelpText(GuiHelpTopics.railLabels());
 
+        assertTrue(helpText.contains("Ctrl+F"));
+        assertTrue(helpText.contains("Space"));
+        assertTrue(helpText.contains("Ctrl-click"));
+        assertTrue(helpText.contains("Shift-click"));
         assertTrue(helpText.contains("JC05262026"));
-        assertTrue(helpText.contains("JC05262026, JC05272026"));
-        assertTrue(helpText.contains("JC05262026/JC05272026"));
-        assertTrue(helpText.contains("same PDF"));
-        assertTrue(helpText.contains("uncheck"));
+        assertTrue(helpText.contains("combined PDF"));
+        assertFalse(helpText.toLowerCase().contains("type one full train code"));
         assertNotNull(helpText);
+    }
+
+    @Test
+    void allHelpTopicsUseConciseOperatorTone() {
+        List<List<GuiHelpSupport.HelpSection>> topics = List.of(
+                GuiHelpTopics.mainWindow(),
+                GuiHelpTopics.railLabels(),
+                GuiHelpTopics.barcodeGenerator(),
+                GuiHelpTopics.barcodeAdvancedSettings(),
+                GuiHelpTopics.zplPreview(),
+                GuiHelpTopics.queuePrint(),
+                GuiHelpTopics.settings(),
+                GuiHelpTopics.advancedSettings(),
+                GuiHelpTopics.updates(),
+                GuiHelpTopics.analyzers()
+        );
+
+        for (List<GuiHelpSupport.HelpSection> topic : topics) {
+            String helpText = GuiHelpSupport.formatHelpText(topic).toLowerCase();
+            assertFalse(helpText.contains("type or paste"));
+            assertFalse(helpText.contains("click load"));
+            assertFalse(helpText.contains("click generate"));
+            assertFalse(helpText.contains("left-click"));
+            assertFalse(helpText.contains("right-click"));
+            assertFalse(helpText.contains("when those options are available"));
+        }
     }
 }

--- a/gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupportTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/rail/RailDialogExecutionSupportTest.java
@@ -1,6 +1,7 @@
 package com.tbg.wms.cli.gui.rail;
 
 import com.tbg.wms.cli.gui.LabelWorkflowService;
+import com.tbg.wms.core.rail.RailCarCard;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
@@ -24,16 +25,22 @@ class RailDialogExecutionSupportTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> support.preparePreviewRequest(" "));
 
-        assertEquals("Train ID is required.", ex.getMessage());
-        assertEquals("JC03182026", support.preparePreviewRequest(" JC03182026 ").trainId());
+        assertEquals("At least one train ID is required.", ex.getMessage());
+        assertEquals(List.of("JC03182026"), support.preparePreviewRequest(" JC03182026 ").trainIds());
+        assertEquals(
+                List.of("JC03182026", "JC04152026"),
+                support.preparePreviewRequest("JC03182026, JC04152026").trainIds()
+        );
     }
 
     @Test
     void prepareGenerationRequest_shouldRespectPrintTargetModes() throws Exception {
         RailWorkflowService.PreparedRailJob job = preparedJob();
+        List<RailCarCard> selectedCards = List.of(card("1"));
 
         RailDialogExecutionSupport.GenerationRequest fileRequest = support.prepareGenerationRequest(
                 job,
+                selectedCards,
                 "",
                 new LabelWorkflowService.PrinterOption("FILE", "Print to File", ""),
                 false,
@@ -41,6 +48,7 @@ class RailDialogExecutionSupportTest {
         );
         RailDialogExecutionSupport.GenerationRequest printRequest = support.prepareGenerationRequest(
                 job,
+                selectedCards,
                 "out\\rail",
                 new LabelWorkflowService.PrinterOption("RAIL1", "Rail 1", "10.0.0.1", List.of("RAIL")),
                 false,
@@ -50,9 +58,27 @@ class RailDialogExecutionSupportTest {
         assertNull(fileRequest.outputDirectory());
         assertEquals("FILE", fileRequest.printerId());
         assertFalse(fileRequest.shouldPrint());
+        assertEquals(1, fileRequest.selectedCards().size());
         assertEquals(Path.of("out\\rail"), printRequest.outputDirectory());
         assertEquals("RAIL1", printRequest.printerId());
         assertTrue(printRequest.shouldPrint());
+    }
+
+    @Test
+    void prepareGenerationRequest_shouldRejectEmptySelection() throws Exception {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> support.prepareGenerationRequest(
+                        preparedJob(),
+                        List.of(),
+                        "",
+                        new LabelWorkflowService.PrinterOption("FILE", "Print to File", ""),
+                        false,
+                        false
+                )
+        );
+
+        assertEquals("Select at least one rail row to generate.", ex.getMessage());
     }
 
     @Test
@@ -87,5 +113,9 @@ class RailDialogExecutionSupportTest {
                         "JC03182026", List.of(), List.of(), List.of(), Map.of(), Set.of(), Set.of()
                 )
         );
+    }
+
+    private static RailCarCard card(String sequence) {
+        return new RailCarCard("TRAIN1", sequence, "CAR" + sequence, "", List.of(), 1, 0, 0, List.of(), List.of());
     }
 }

--- a/gui/src/test/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModelTest.java
+++ b/gui/src/test/java/com/tbg/wms/cli/gui/rail/RailPrintableCardTableModelTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Tropicana Brands Group
+ */
+package com.tbg.wms.cli.gui.rail;
+
+import com.tbg.wms.core.rail.RailCarCard;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RailPrintableCardTableModelTest {
+
+    @Test
+    void setCardsShouldDefaultAllRowsToPrintable() {
+        RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+
+        model.setCards(List.of(card("TRAIN1", "1"), card("TRAIN1", "2")));
+
+        assertEquals(2, model.getRowCount());
+        assertEquals(Boolean.TRUE, model.getValueAt(0, 0));
+        assertEquals(2, model.selectedCount());
+        assertEquals(2, model.selectedCards().size());
+    }
+
+    @Test
+    void checkboxColumnShouldBeEditableWithoutEditingCardData() {
+        RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+        model.setCards(List.of(card("TRAIN1", "1")));
+
+        model.setValueAt(Boolean.FALSE, 0, 0);
+
+        assertFalse(Boolean.TRUE.equals(model.getValueAt(0, 0)));
+        assertTrue(model.selectedCards().isEmpty());
+        assertTrue(model.isCellEditable(0, 0));
+        assertFalse(model.isCellEditable(0, 1));
+    }
+
+    @Test
+    void bulkActionsShouldUpdatePrintableRows() {
+        RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+        model.setCards(List.of(card("TRAIN1", "1"), card("TRAIN1", "2"), card("TRAIN1", "3")));
+
+        model.clearAllPrintable();
+        assertEquals(0, model.selectedCount());
+
+        model.setAllPrintable();
+        assertEquals(3, model.selectedCount());
+
+        model.invertPrintable();
+        assertEquals(0, model.selectedCount());
+    }
+
+    @Test
+    void togglePrintableRowsShouldAffectOnlyProvidedModelRows() {
+        RailCarCard first = card("TRAIN1", "1");
+        RailCarCard second = card("TRAIN1", "2");
+        RailPrintableCardTableModel model = new RailPrintableCardTableModel();
+        model.setCards(List.of(first, second));
+
+        model.togglePrintableRows(new int[]{1});
+
+        assertSame(first, model.selectedCards().get(0));
+        assertEquals(1, model.selectedCount());
+    }
+
+    private static RailCarCard card(String train, String sequence) {
+        return new RailCarCard(train, sequence, "CAR" + sequence, "LOAD" + sequence,
+                List.of(), 1, 2, 0, List.of(), List.of());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.tbg.wms</groupId>
     <artifactId>wms-pallet-tag-system</artifactId>
-    <version>1.7.6</version>
+    <version>1.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WMS Pallet Tag System</name>


### PR DESCRIPTION
## Summary
- improve rail labels with multi-train input parsing, documented 4x2 sheet layout, larger typography, complete route/item rendering, and combined PDF generation
- add explicit printable-row selection in the Rail Labels GUI and contextual Help buttons/topics across GUI tools
- start the `1.8.0-SNAPSHOT` release line and add SRP/SOLID architecture documentation plus release-checklist gates

## Follow-up work on this PR
- refine help message copy and examples based on operator review
- continue focused SRP refactors on GUI coordination boundaries
- run additional code-efficiency checks before final merge

## Test Plan
- [x] `mvnw.cmd -q -pl core,db,gui,cli -am test`
- [x] `mvnw.cmd -q -pl cli -am package -DskipTests`
- [x] `java -jar cli\target\cli-1.8.0-SNAPSHOT.jar --help`

Closes #42
Refs #43